### PR TITLE
Improved compliance tests for OpenModelica and JModelica.org

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -1713,7 +1713,7 @@ successfully (={:.1%})"\
         self._reporter.writeOutput('OpenModelica script {} created'.format(mosfilename))
         return mosfilename
 
-    def testOM(self, cmpl=True, simulate=False,
+    def test_OpenModelica(self, cmpl=True, simulate=False,
                       packages=['Examples'], number=-1):
         """
         Test the library compliance with OpenModelica.
@@ -1735,7 +1735,7 @@ successfully (={:.1%})"\
           1. In a python console or script, cd to the root folder of the library
 
              >>> t = Tester() # doctest: +SKIP
-             >>> t.testOpenModelica(...) # doctest: +SKIP
+             >>> t.test_OpenModelica(...) # doctest: +SKIP
 
         """
         import shutil


### PR DESCRIPTION
I think with these commits, we can close issue #1.
There is one flaw: I included a hard coded path to the openmodelica library.  This will not work on a different setup than mine.  

The path has to point to MSL, this is the current implementation:

```
env['OPENMODELICALIBRARY'] = worDir + ':/usr/lib/omlibrary'
```

How can we solve this?
