### PR TITLE
External packages

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -131,7 +131,9 @@ class Tester:
 
         # Flag to delete temporary directories.
         self._deleteTemporaryDirectories = kwargs.get('cleanup', True)
-        self._loadPackages=[]
+        
+        # External packages that need to be loaded
+        self._externalPackages=[]
 
         # Flag to use existing results instead of running a simulation
         self._useExistingResults = False
@@ -194,6 +196,14 @@ class Tester:
         self._temDir = dirs
         self.deleteTemporaryDirectories(False)
         self._useExistingResults = True
+        
+    def setExternalPackages(self, dirs):
+        ''' This function allows to use external packages that are needed for the tested package. This only works for dymola.
+
+        :param dirs: A list of paths to package.mo files that need to be loaded after the main package.
+
+        '''
+        self._externalPackages = dirs
 
     def setNumberOfThreads(self, number):
         ''' Set the number of parallel threads that are used to run the regression tests.
@@ -1219,12 +1229,13 @@ len(yNew)    = %d""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew)))
 
             if self._modelicaCmd == 'dymola':
                 runFil.write('openModel("package.mo");\n')
-                # store current work directory path before overwriting it by loading new packages
-                runFil.write('path = Modelica.Utilities.System.getWorkDirectory()\n')
-                for package in self._loadPackages:
-                    runFil.write('openModel("' + package + '");\n')
-                # reset original work directory path
-                runFil.write('Modelica.Utilities.System.setWorkDirectory(path)\n')
+                if len(self._externalPackages) > 0:
+                    # store current work directory path before overwriting it by loading new packages
+                    runFil.write('path = Modelica.Utilities.System.getWorkDirectory()\n')
+                    for package in self._externalPackages:
+                        runFil.write('openModel("' + package + '");\n')
+                    # reset original work directory path
+                    runFil.write('Modelica.Utilities.System.setWorkDirectory(path)\n')
                 
             elif self._modelicaCmd == 'omc':
                 runFil.write('loadModel(Modelica, {"3.2"});\n')


### PR DESCRIPTION
These changes allow adding external packages to be loaded prior to running the unit tests. I do not have an openmodelica version running so I did not add an implementation for this.
