### PR TITLE
Add possibility to open a *.mos-script instead of package.mo from packagePath

### DIFF
--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -100,12 +100,11 @@ class Simulator:
         # Check whether the file package.mo or a .mos-script exists in the directory specified
         fileMo = os.path.abspath(os.path.join(packagePath, "package.mo"))
         if os.path.isfile(fileMo) == False:
-            listOfFiles = [f for f in os.listdir(packagePath) if os.path.isfile(os.path.join(packagePath,f)) ]
+            listOfFiles = [f for f in os.listdir(packagePath) if os.path.isfile(os.path.join(packagePath,f))]
             for i in listOfFiles:
                 if '.mos' in i:
                     self.ScriptToOpen = i
                     self.openAPackage = False
-
             if self.openAPackage == True:
                 msg = "The directory '%s' does not contain the required " % packagePath
                 msg +="file '%s' or a *.mos-script to open multiple libraries." %fileMo


### PR DESCRIPTION
This pull request is not meant for direct merging, rather for a discussion if such a feature is interesting for you, too:
The current buildingsPy implementation can open a package from the packagePath, which I presume is meant for opening the Buildings Library. In our case, we often need to open more than one library in addition to the MSL. This implementation is still a bit rough, but it checks in case packagePath does not contain a package.mo file whether it instead contains a *.mos-script. From this script, it is thus possible to open multiple libraries. 
