### PR TITLE
Issue70 simulation: test for parameter changes and simulation errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,13 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+/BuildingsPy.log
+/openmdao_log.txt
+/package.order
+/plot.pdf
+/plot.png
+/roomTemperatures.png
+/run_simulate.mos
+/run_translate.mos
+/simulator.log
+/translator.log

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ nosetests.xml
 /run_translate.mos
 /simulator.log
 /translator.log
+/BooleanParameters.mat
+/Constants.mat
+/dslog.txt
+/ParameterEvaluation.mat

--- a/buildingspy/examples/dymola/case1/.gitignore
+++ b/buildingspy/examples/dymola/case1/.gitignore
@@ -4,3 +4,4 @@
 /run_translate.mos
 /simulator.log
 /translator.log
+/fullRobot.mat

--- a/buildingspy/examples/dymola/case2/.gitignore
+++ b/buildingspy/examples/dymola/case2/.gitignore
@@ -3,3 +3,4 @@
 /run_translate.mos
 /simulator.log
 /translator.log
+/fullRobot.mat

--- a/buildingspy/examples/dymola/runSimulationTranslated.py
+++ b/buildingspy/examples/dymola/runSimulationTranslated.py
@@ -45,7 +45,7 @@ def main():
     po = Pool()
     po.map(simulateCase, li)
     # clean up
-    s2._deleteTemporaryDirectory(s._translateDir_)
+    s2.deleteTranslateDirectory()
 
 # Main function
 if __name__ == '__main__':

--- a/buildingspy/io/outputfile.py
+++ b/buildingspy/io/outputfile.py
@@ -94,7 +94,56 @@ def get_model_statistics(log_file, simulator):
             ret["initialization"]=dicIni
         ret["simulation"]=dicSim
         return ret
+    
+def get_errors_and_warnings(log_file, simulator):
+    """ Open the simulation file *log_file* and return a dictionary
+        with the model warnings and errors.
 
+        :log_file: The name of the log file.
+        :simulator: The file format. Currently, the only supported
+                    value is ``dymola``.
+
+        With Dymola, a log file with the simulation statistics can
+        be written using syntax such as
+
+        >>> simulateModel(...);                        #doctest: +SKIP
+        >>> savelog("simulator.log");                  #doctest: +SKIP
+        
+        This function returns a dictionary. The top level keys are
+        ``warnings`` and ``errors``, which contain list of warning and 
+        error messages.
+    """
+    
+    import os
+
+    if simulator != "dymola":
+        raise ValueError('Argument "simulator" needs to be set to "dymola".')
+
+    if not os.path.isfile(log_file):
+        raise IOError("File {} does not exist".format(log_file))
+
+    with open(log_file) as fil:
+        lines = fil.readlines();
+        # Instantiate lists that are used for the return value
+        
+        ret = {}
+        listWarn = []
+        listErr = []
+    
+        WARN="Warning:"
+        ERR="... Error message from dymosim"
+        
+        for index, lin in enumerate(lines):
+            if lin.find(WARN) >= 0:
+                temp = lin.rpartition(":")[2].strip()
+                listWarn.append(temp)
+            elif lin.find(ERR) >= 0:
+                listErr.append(lines[index+1].strip())
+                
+        ret["warnings"]=listWarn   
+        ret["errors"]=listErr  
+        return ret
+    
 class Reader:
     """Open the file *fileName* and parse its content.
 

--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -706,6 +706,11 @@ class Simulator(object):
                 self._reporter.writeError("Failed to delete '" +
                                            worDir + ": " + e.strerror)
 
+    def deleteTranslateDirectory(self):
+        ''' Deletes the translate directory. Called after simulate_translated
+        '''
+        self._deleteTemporaryDirectory(self._translateDir_)
+
     def _isExecutable(self, program):
         import os
         import platform

--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -350,8 +350,6 @@ class Simulator(object):
         '''
         import sys
         import os
-        import tempfile
-        import getpass
         import shutil
 
 
@@ -360,10 +358,7 @@ class Simulator(object):
 
         # Get directory name. This ensures for example that if the directory is called xx/Buildings
         # then the simulations will be done in tmp??/Buildings
-        curDir = os.path.abspath(self._packagePath)
-        ds=curDir.split(os.sep)
-        dirNam=ds[len(ds)-1]
-        worDir = os.path.join(tempfile.mkdtemp(prefix='tmp-simulator-' + getpass.getuser() + '-'), dirNam)
+        worDir = self._create_worDir()
         # Copy directory
         shutil.copytree(os.path.abspath(self._packagePath), worDir)
 
@@ -442,8 +437,6 @@ class Simulator(object):
         '''
         import sys
         import os
-        import tempfile
-        import getpass
         import shutil
 
 
@@ -452,10 +445,7 @@ class Simulator(object):
 
         # Get directory name. This ensures for example that if the directory is called xx/Buildings
         # then the simulations will be done in tmp??/Buildings
-        curDir = os.path.abspath(self._packagePath)
-        ds=curDir.split(os.sep)
-        dirNam=ds[len(ds)-1]
-        worDir = os.path.join(tempfile.mkdtemp(prefix='tmp-simulator-' + getpass.getuser() + '-'), dirNam)
+        worDir = self._create_worDir()
         self._translateDir_ = worDir
         # Copy directory
         shutil.copytree(os.path.abspath(self._packagePath), worDir)
@@ -539,8 +529,6 @@ class Simulator(object):
         '''
         import sys
         import os
-        import tempfile
-        import getpass
         import shutil
 
         # Delete dymola output files
@@ -548,10 +536,7 @@ class Simulator(object):
 
         # Get directory name. This ensures for example that if the directory is called xx/Buildings
         # then the simulations will be done in tmp??/Buildings
-        curDir = os.path.abspath(self._packagePath)
-        ds=curDir.split(os.sep)
-        dirNam=ds[len(ds)-1]
-        worDir = os.path.join(tempfile.mkdtemp(prefix='tmp-simulator-' + getpass.getuser() + '-'), dirNam)
+        worDir = self._create_worDir()
         # Copy translate directory
         shutil.copytree(self._translateDir_, worDir)
 
@@ -880,3 +865,16 @@ class Simulator(object):
             dec.append('{param}={value}'.format(param=k, value=s))
 
         return dec
+
+    def _create_worDir(self):
+        ''' Create working directory
+        '''
+        import os
+        import tempfile
+        import getpass
+        curDir = os.path.abspath(self._packagePath)
+        ds=curDir.split(os.sep)
+        dirNam=ds[len(ds)-1]
+        worDir = os.path.join(tempfile.mkdtemp(prefix='tmp-simulator-' + getpass.getuser() + '-'), dirNam)
+        
+        return worDir

--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -553,7 +553,7 @@ class Simulator(object):
         dirNam=ds[len(ds)-1]
         worDir = os.path.join(tempfile.mkdtemp(prefix='tmp-simulator-' + getpass.getuser() + '-'), dirNam)
         # Copy translate directory
-        shutil.move(self._translateDir_, worDir)
+        shutil.copytree(self._translateDir_, worDir)
 
         # Construct the model instance with all parameter values
         # (without package redeclarations)

--- a/buildingspy/tests/test_simulate_Simulator.py
+++ b/buildingspy/tests/test_simulate_Simulator.py
@@ -203,11 +203,6 @@ class Test_simulate_Simulator(unittest.TestCase):
         This tests whether an exception is thrown if
         one attempts to change a parameter that is fixed after compilation
         '''
-        import numpy as np
-
-        from buildingspy.io.reporter import Reporter
-        from buildingspy.io.outputfile import Reader
-        from buildingspy.io.outputfile import get_errors_and_warnings
 
         s = Simulator("MyModelicaLibrary.Examples.ParameterEvaluation", "dymola", packagePath=self._packagePath)
         s.translate()

--- a/buildingspy/tests/test_simulate_Simulator.py
+++ b/buildingspy/tests/test_simulate_Simulator.py
@@ -67,7 +67,7 @@ class Test_simulate_Simulator(unittest.TestCase):
         s.setNumberOfIntervals(50)
         s.setResultFile("myResults")
         s.exitSimulator(True)
-        s.deleteOutputFiles()
+        #s.deleteOutputFiles()
         s.showGUI(False)
 #        s.printModelAndTime()
         s.showProgressBar(False)
@@ -132,6 +132,9 @@ class Test_simulate_Simulator(unittest.TestCase):
         np.testing.assert_allclose(3.2, r.max('const2[3, 2].y'))
 
         np.testing.assert_allclose(0, r.max('const3.y'))
+        # Delete output files
+        s.deleteOutputFiles()
+        s.deleteLogFiles()
 
     def test_setBooleanParameterValues(self):
         '''
@@ -157,6 +160,9 @@ class Test_simulate_Simulator(unittest.TestCase):
         self.assertEqual(p[0], 1.0)
         (_, p) = r.values('p2')
         self.assertEqual(p[0], 0.0)
+        # Delete output files
+        s.deleteOutputFiles()
+        s.deleteLogFiles()
 
     def test_translate_simulate(self):
         '''
@@ -178,7 +184,7 @@ class Test_simulate_Simulator(unittest.TestCase):
         s.setSolver("dassl")
         s.setNumberOfIntervals(50)
         s.setResultFile("myResults")
-        s.deleteOutputFiles()
+        #s.deleteOutputFiles()
         s.translate()
         s.simulate_translated()
         # Read the result and test their validity
@@ -195,7 +201,7 @@ class Test_simulate_Simulator(unittest.TestCase):
         # clean up translate temporary dir
         s.deleteTranslateDirectory()
 
-    def test_translate_simulate_exception(self):
+    def test_translate_simulate_exception_parameter(self):
         '''
         Tests the :mod:`buildingspy.simulate.Simulator.translate` and
         the :mod:`buildingspy.simulate.Simulator.simulate_translated`
@@ -209,7 +215,36 @@ class Test_simulate_Simulator(unittest.TestCase):
         s.setSolver("dassl")
         s.addParameters({'x': 0.2})
         # The next call must throw an exception.
-        self.assertRaises(AssertionError, s.simulate_translated)
+        self.assertRaises(IOError, s.simulate_translated)
+        # clean up translate temporary dir
+        s.deleteTranslateDirectory()
+        # Delete output files
+        s.deleteOutputFiles()
+        s.deleteLogFiles()
+        # This is called to clean up after an exception in simulate_translated().
+        s.deleteSimulateDirectory()
+        
+    def test_translate_simulate_exception_error(self):
+        '''
+        Tests the :mod:`buildingspy.simulate.Simulator.translate` and
+        the :mod:`buildingspy.simulate.Simulator.simulate_translated`
+        method.
+        This tests whether an exception is thrown if
+        the simulation settings are not appropriate.
+        '''
+
+        s = Simulator("MyModelicaLibrary.Examples.ParameterEvaluation", "dymola", packagePath=self._packagePath)
+        s.translate()
+        s.setSolver("radau")
+        # The next call must throw an exception.
+        self.assertRaises(IOError, s.simulate_translated)
+        # clean up translate temporary dir
+        s.deleteTranslateDirectory()
+        # Delete output files
+        s.deleteOutputFiles()
+        s.deleteLogFiles()
+        # This is called to clean up after an exception in simulate_translated().
+        s.deleteSimulateDirectory()
 
 if __name__ == '__main__':
     unittest.main()

--- a/buildingspy/tests/test_simulate_Simulator.py
+++ b/buildingspy/tests/test_simulate_Simulator.py
@@ -193,7 +193,7 @@ class Test_simulate_Simulator(unittest.TestCase):
         s.deleteOutputFiles()
         s.deleteLogFiles()
         # clean up translate temporary dir
-        s._deleteTemporaryDirectory(s._translateDir_)
+        s.deleteTranslateDirectory()
 
     def test_translate_simulate_exception(self):
         '''
@@ -205,17 +205,16 @@ class Test_simulate_Simulator(unittest.TestCase):
         '''
         import numpy as np
 
+        from buildingspy.io.reporter import Reporter
         from buildingspy.io.outputfile import Reader
-
+        from buildingspy.io.outputfile import get_errors_and_warnings
 
         s = Simulator("MyModelicaLibrary.Examples.ParameterEvaluation", "dymola", packagePath=self._packagePath)
         s.translate()
+        s.setSolver("dassl")
         s.addParameters({'x': 0.2})
         # The next call must throw an exception.
-        # FIXME: This does not throw any error, it simply simulates the model with
-        #        the old value for the parameter.
-        s.simulate_translated()
-
+        self.assertRaises(AssertionError, s.simulate_translated)
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,5 +1,0 @@
-/BooleanParameters.mat
-/Constants.mat
-/run_simulate.mos
-/run_translate.mos
-/translator.log


### PR DESCRIPTION
I replaced the call `_deleteTemporaryDirectory` by a public method. Also two tests were added to check for (1) if parameters were actually changed after `translate` and (2) if an error occured during simulation and if so the error is send to the reporter.