### PR TITLE
update on issue81 branch

### DIFF
--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -5,6 +5,10 @@
 #
 # MWetter@lbl.gov                            2014-04-15
 #######################################################
+from __future__ import unicode_literals
+import os
+from io import open
+
 class Annex60:
     ''' Class that merges a Modelica library with the `Annex60` library.
 
@@ -22,7 +26,6 @@ class Annex60:
         :param annex60_dir: Directory where the `Annex60` library is located.
         :param dest_dir: Directory where the library to be updated is located.
         '''
-        import os
 
         # Check arguments
         def isValidLibrary(lib_home):
@@ -70,8 +73,6 @@ class Annex60:
         :param source_file: Name of the file to be copied.
         :param destination_file: Name of the new file.
         """
-        import os
-        from io import open
         import re
         import string
 
@@ -146,10 +147,7 @@ class Annex60:
                 >>> mer.merge()                            # doctest: +SKIP
 
         """
-        import os
-        from io import open
         import shutil
-
         import buildingspy.development.refactor as r
 
         # path where a list of all copied files is saved

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -5,6 +5,9 @@
 #
 # MWetter@lbl.gov                            2014-04-15
 #######################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 import os
 from io import open

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -14,6 +14,9 @@
   * rewrite the `package.order` file.
 
 '''
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 import os
 from io import open

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -14,6 +14,7 @@
   * rewrite the `package.order` file.
 
 '''
+from __future__ import unicode_literals
 import os
 from io import open
 

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -543,9 +543,9 @@ class Tester:
 
           >>> import buildingspy.development.regressiontest as r
           >>> r.Tester.get_plot_variables('y = {"a", "b", "c"}')
-          ['a', 'b', 'c']
+          [u'a', u'b', u'c']
           >>> r.Tester.get_plot_variables('... x}, y = {"a", "b", "c"}, z = {...')
-          ['a', 'b', 'c']
+          [u'a', u'b', u'c']
           >>> r.Tester.get_plot_variables("y=abc") is None
           True
 

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -6,6 +6,7 @@
 # MWetter@lbl.gov                            2011-02-23
 #######################################################
 from __future__ import division
+from __future__ import unicode_literals
 import sys
 import os
 from io import open

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -5,7 +5,9 @@
 #
 # MWetter@lbl.gov                            2011-02-23
 #######################################################
+from __future__ import absolute_import
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 import sys
 import os

--- a/buildingspy/development/validator.py
+++ b/buildingspy/development/validator.py
@@ -5,6 +5,9 @@
 #
 # MWetter@lbl.gov                            2013-05-31
 #######################################################
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 from io import open
 

--- a/buildingspy/development/validator.py
+++ b/buildingspy/development/validator.py
@@ -10,6 +10,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 from io import open
+import os
 
 class Validator:
     ''' Class that validates ``.mo`` files for the correct html syntax.
@@ -48,7 +49,6 @@ class Validator:
             >>> errStr = val.validateHTMLInPackage(myMoLib)
 
         '''
-        import os
         errMsg = list()
 
         # Make sure that the parameter rootDir points to a Modelica package.

--- a/buildingspy/development/validator.py
+++ b/buildingspy/development/validator.py
@@ -5,7 +5,8 @@
 #
 # MWetter@lbl.gov                            2013-05-31
 #######################################################
-
+from __future__ import unicode_literals
+from io import open
 
 class Validator:
     ''' Class that validates ``.mo`` files for the correct html syntax.
@@ -77,7 +78,6 @@ Modelica package. Expected file '%s'."
 
         '''
         from tidylib import tidy_document
-        from io import open
         # Open file.
         f = open(moFile, mode="r", encoding="utf-8")
         lines = f.readlines()

--- a/buildingspy/tests/test_development_merger.py
+++ b/buildingspy/tests/test_development_merger.py
@@ -4,6 +4,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 import unittest
+import os
 
 class Test_development_merger_Annex60(unittest.TestCase):
     """
@@ -16,7 +17,6 @@ class Test_development_merger_Annex60(unittest.TestCase):
     
     def __init__(self, *args, **kwargs):
 #        unittest.TestCase.__init__(self, name) 
-        import os
         import tempfile
         from git import Repo
       

--- a/buildingspy/tests/test_development_merger.py
+++ b/buildingspy/tests/test_development_merger.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import unittest
 
 class Test_development_merger_Annex60(unittest.TestCase):

--- a/buildingspy/tests/test_simulate_Simulator.py
+++ b/buildingspy/tests/test_simulate_Simulator.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
 import unittest
 import os
 from buildingspy.simulate.Simulator import Simulator


### PR DESCRIPTION
Using future unicode_literals seems to be the right direction, but now I get a new error:
```
File "buildingspy\development\regressiontest.py", line 2232, in run
        json.dump({"testCase": stat}, logFil, indent=4, separators=(',', ': '))
...
    TypeError: must be unicode, not str
```
Opening the PR for discussion, not yet ready to merge