### PR TITLE
Issue94 futurize 2nd

### DIFF
--- a/buildingspy/development/error_dictionary.py
+++ b/buildingspy/development/error_dictionary.py
@@ -7,7 +7,8 @@
 # MWetter@lbl.gov                            2015-11-17
 #######################################################
 
-class ErrorDictionary:
+from builtins import object
+class ErrorDictionary(object):
     ''' Class that contains data fields needed for the
         error checking of the regression tests.
 
@@ -147,7 +148,7 @@ class ErrorDictionary:
         """ Return a copy of the tool messages as a list.
         """
         ret = list()
-        keys = self.keys()
+        keys = list(self.keys())
         for key in keys:
             ret.append(self._error_dict[key]['tool_message'])
         return ret

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -5,7 +5,8 @@
 #
 # MWetter@lbl.gov                            2014-04-15
 #######################################################
-class Annex60:
+from builtins import object
+class Annex60(object):
     ''' Class that merges a Modelica library with the `Annex60` library.
 
         Both libraries need to have the same package structure.
@@ -87,7 +88,7 @@ class Annex60:
         f_sou = open(source_file, 'r')
         lines = list()
         for _, lin in enumerate(f_sou):
-            for ori, new in rep.iteritems():
+            for ori, new in rep.items():
                 lin = string.replace(lin, ori, new)
             lines.append(lin)
         f_sou.close

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -15,6 +15,7 @@
 
 '''
 from __future__ import print_function
+from builtins import range
 import os
 
 __all__ = ["create_modelica_package", "move_class", "write_package_order"]

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -7,6 +7,14 @@
 #######################################################
 from __future__ import division
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import zip
+from builtins import map
+from builtins import str
+from builtins import input
+from builtins import range
+from builtins import object
 import sys
 import os
 
@@ -48,7 +56,7 @@ def runSimulation(worDir, cmd):
         sys.stderr.write("Users stopped simulation in %s.\n" % worDir)
 
 
-class Tester:
+class Tester(object):
     ''' Class that runs all regression tests using Dymola.
 
     Initiate with the following optional arguments:
@@ -1047,7 +1055,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
         retVal = "%.20f" % value
         # Cut trailing zeros to avoid output such as 1.0000000
         i = len(retVal)-1;
-        for pos in xrange(i, 0, -1):
+        for pos in range(i, 0, -1):
             if retVal[pos] != '0':
                 i = pos+1
                 break
@@ -1079,7 +1087,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             # written twice to the reference data file.
             s = set()
             for pai in y_sim:
-                for k, v in pai.items():
+                for k, v in list(pai.items()):
                     if k not in s:
                         s.add(k)
                         f.write(k + '=')
@@ -1171,7 +1179,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             sys.stdout.write("             for %s\n" % refFilNam)
             sys.stdout.write("             Accept new results?\n")
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
-                ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 # update the flag
                 updateReferenceData = True
@@ -1269,7 +1277,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
                     foundError = True
                     while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                         print("             Accept new results and update reference file in library?")
-                        ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                        ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                     if ans == "y" or ans == "Y":
                         # Write results to reference file
                         updateReferenceData = True
@@ -1277,7 +1285,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
 
             # The time interval is the same for the stored and the current data.
             # Check the accuracy of the simulation.
-            for varNam in pai.keys(): # Iterate over the variable names that are to be plotted together
+            for varNam in list(pai.keys()): # Iterate over the variable names that are to be plotted together
                 if varNam != 'time':
                     if varNam in y_ref:
                         # Check results
@@ -1329,7 +1337,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
                 color=['k', 'r', 'b', 'g', 'c', 'm']
                 iPai = -1
                 t_sim = pai['time']
-                for varNam in pai.keys():
+                for varNam in list(pai.keys()):
                     iPai += 1
                     if iPai > len(color)-1:
                         iPai = 0
@@ -1377,7 +1385,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             self._figSize=gcf.get_size_inches()
 
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
-                ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 # update the flag
                 updateReferenceData = True
@@ -1434,7 +1442,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             print("*** Warning: Reference file {} does not yet exist.".format(reference_file_name))
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                 print("             Create new file?")
-                ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                 self._reporter.writeWarning("*** Warning: Wrote new reference file %s." %
@@ -1457,7 +1465,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             if found_differences:
                 while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                     print("             Rewrite file?")
-                    ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                    ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                 if ans == "y" or ans == "Y":
                     self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                     self._reporter.writeWarning("*** Warning: Rewrote reference file %s due to new FMU statistics." %
@@ -1470,7 +1478,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             print("*** Warning: Reference file {} has no FMU statistics.".format(reference_file_name))
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                 print("             Rewrite file?")
-                ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                 self._reporter.writeWarning("*** Warning: Rewrote reference file %s as the old one had no FMU statistics." %
@@ -1606,7 +1614,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
                         print("*** Warning: Reference file {} does not yet exist.".format(refFilNam))
                         while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                             print("             Create new file?")
-                            ans = raw_input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
+                            ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                         if ans == "y" or ans == "Y":
                             updateReferenceData = True
                     if updateReferenceData:    # If the reference data of any variable was updated
@@ -1658,7 +1666,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             else:
                 key = 'FMUExport'
 
-            for k, v in self._error_dict.get_dictionary().iteritems():
+            for k, v in self._error_dict.get_dictionary().items():
                 if ele[key][k] > 0:
                     self._reporter.writeWarning(v["model_message"].format(ele[key]["command"]))
                     self._error_dict.increment_counter(k)
@@ -1671,7 +1679,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             print("Number of models that failed to export as an FMU             : {}".format(iFMU))
 
         # Write summary messages
-        for _, v in self._error_dict.get_dictionary().iteritems():
+        for _, v in self._error_dict.get_dictionary().items():
             counter = v['counter']
             if counter > 0:
                 print(v['summary_message'].format(counter))
@@ -1800,7 +1808,7 @@ iJac=sum(Modelica.Utilities.Strings.count(lines, "Number of numerical Jacobians:
             runFil.write(template.format(**values))
 
             # Do the other tests
-            for _, v in self._error_dict.get_dictionary().iteritems():
+            for _, v in self._error_dict.get_dictionary().items():
                 template = r"""  {}=sum(Modelica.Utilities.Strings.count(lines, "{}"));
 """
                 runFil.write(template.format(v["buildingspy_var"], v["tool_message"]))
@@ -1808,7 +1816,7 @@ iJac=sum(Modelica.Utilities.Strings.count(lines, "Number of numerical Jacobians:
 
         def _write_translation_stats(runFil, values):
 
-            for k, v in self._error_dict.get_dictionary().iteritems():
+            for k, v in self._error_dict.get_dictionary().items():
                 if k != "numerical Jacobians":
                     template = r"""
 Modelica.Utilities.Streams.print("        \"{}\"  : " + String({}) + ",", "{}");"""
@@ -2190,7 +2198,7 @@ getErrorString();
                 po = multiprocessing.Pool(self._nPro)
                 po.map(functools.partial(runSimulation,
                                          cmd=cmd),
-                       map(lambda x: os.path.join(x, libNam), self._temDir))
+                       [os.path.join(x, libNam) for x in self._temDir])
             else:
                 runSimulation(os.path.join(self._temDir[0], libNam), cmd)
 
@@ -2355,7 +2363,7 @@ getErrorString();
         import shutil
         import sys
 
-        from cStringIO import StringIO
+        from io import StringIO
 
         if number < 0:
             number = 1e15
@@ -2452,16 +2460,16 @@ getErrorString();
         :param simulate: Set to ``True`` to cause the model to be simulated.
         """
 
-        count_cmpl = lambda x: [True for _, v in x.items()
+        count_cmpl = lambda x: [True for _, v in list(x.items())
                                 if v['compilation_ok']]
-        list_failed_cmpl = lambda x: [k for k, v in x.items()
+        list_failed_cmpl = lambda x: [k for k, v in list(x.items())
                                       if not v['compilation_ok']]
-        count_load = lambda x: [True for _, v in x.items() if v['load_ok']]
-        list_failed_load = lambda x: [k for k, v in x.items()
+        count_load = lambda x: [True for _, v in list(x.items()) if v['load_ok']]
+        list_failed_load = lambda x: [k for k, v in list(x.items())
                                       if not v['load_ok']]
 
-        count_sim = lambda x: [True for _, v in x.items() if v['sim_ok']]
-        list_failed_sim = lambda x: [k for k, v in x.items()
+        count_sim = lambda x: [True for _, v in list(x.items()) if v['sim_ok']]
+        list_failed_sim = lambda x: [k for k, v in list(x.items())
                                       if not v['sim_ok']]
 
         nbr_tot = len(self._jmstats)

--- a/buildingspy/development/validator.py
+++ b/buildingspy/development/validator.py
@@ -7,7 +7,9 @@
 #######################################################
 
 
-class Validator:
+from builtins import range
+from builtins import object
+class Validator(object):
     ''' Class that validates ``.mo`` files for the correct html syntax.
     '''
     def __init__(self):

--- a/buildingspy/examples/dymola/plotResult.py
+++ b/buildingspy/examples/dymola/plotResult.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 def main():
     ''' Main method that plots the results
     '''
@@ -22,21 +25,21 @@ def main():
     fig = plt.figure()
     ax = fig.add_subplot(211)
 
-    ax.plot(time1/3600, T1-273.15, 'r', label='$T_1$')
-    ax.plot(time2/3600, T2-273.15, 'b', label='$T_2$')
+    ax.plot(old_div(time1,3600), T1-273.15, 'r', label='$T_1$')
+    ax.plot(old_div(time2,3600), T2-273.15, 'b', label='$T_2$')
     ax.set_xlabel('time [h]')
     ax.set_ylabel('temperature [$^\circ$C]')
-    ax.set_xticks(range(25))
+    ax.set_xticks(list(range(25)))
     ax.set_xlim([0, 24])
     ax.legend()
     ax.grid(True)
 
     ax = fig.add_subplot(212)
-    ax.plot(time1/3600, y1, 'r', label='$y_1$')
-    ax.plot(time2/3600, y2, 'b', label='$y_2$')
+    ax.plot(old_div(time1,3600), y1, 'r', label='$y_1$')
+    ax.plot(old_div(time2,3600), y2, 'b', label='$y_2$')
     ax.set_xlabel('time [h]')
     ax.set_ylabel('y [-]')
-    ax.set_xticks(range(25))
+    ax.set_xticks(list(range(25)))
     ax.set_xlim([0, 24])
     ax.legend()
     ax.grid(True)

--- a/buildingspy/examples/dymola/plotResult.py
+++ b/buildingspy/examples/dymola/plotResult.py
@@ -1,6 +1,5 @@
 from __future__ import division
 from builtins import range
-from past.utils import old_div
 def main():
     ''' Main method that plots the results
     '''
@@ -25,8 +24,8 @@ def main():
     fig = plt.figure()
     ax = fig.add_subplot(211)
 
-    ax.plot(old_div(time1,3600), T1-273.15, 'r', label='$T_1$')
-    ax.plot(old_div(time2,3600), T2-273.15, 'b', label='$T_2$')
+    ax.plot(time1/3600, T1-273.15, 'r', label='$T_1$')
+    ax.plot(time2/3600, T2-273.15, 'b', label='$T_2$')
     ax.set_xlabel('time [h]')
     ax.set_ylabel('temperature [$^\circ$C]')
     ax.set_xticks(list(range(25)))
@@ -35,8 +34,8 @@ def main():
     ax.grid(True)
 
     ax = fig.add_subplot(212)
-    ax.plot(old_div(time1,3600), y1, 'r', label='$y_1$')
-    ax.plot(old_div(time2,3600), y2, 'b', label='$y_2$')
+    ax.plot(time1/3600, y1, 'r', label='$y_1$')
+    ax.plot(time2/3600, y2, 'b', label='$y_2$')
     ax.set_xlabel('time [h]')
     ax.set_ylabel('y [-]')
     ax.set_xticks(list(range(25)))

--- a/buildingspy/io/outputfile.py
+++ b/buildingspy/io/outputfile.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+from __future__ import division
+from builtins import range
+from builtins import object
+from past.utils import old_div
 from buildingspy.thirdParty.dymat.DyMat import DyMatFile
 
 def get_model_statistics(log_file, simulator):
@@ -144,7 +148,7 @@ def get_errors_and_warnings(log_file, simulator):
         ret["errors"]=listErr  
         return ret
     
-class Reader:
+class Reader(object):
     """Open the file ``fileName`` and parse its content.
 
     :param fileName: The name of the file.
@@ -274,7 +278,7 @@ class Reader:
            -21.589191160164773
         '''
         t=self.values(varName)[0]
-        r = self.integral(varName)/(max(t)-min(t))
+        r = old_div(self.integral(varName),(max(t)-min(t)))
         return r
 
     def min(self, varName):

--- a/buildingspy/io/outputfile.py
+++ b/buildingspy/io/outputfile.py
@@ -2,7 +2,6 @@
 from __future__ import division
 from builtins import range
 from builtins import object
-from past.utils import old_div
 from buildingspy.thirdParty.dymat.DyMat import DyMatFile
 
 def get_model_statistics(log_file, simulator):
@@ -278,7 +277,7 @@ class Reader(object):
            -21.589191160164773
         '''
         t=self.values(varName)[0]
-        r = old_div(self.integral(varName),(max(t)-min(t)))
+        r = self.integral(varName)/(max(t)-min(t))
         return r
 
     def min(self, varName):

--- a/buildingspy/io/postprocess.py
+++ b/buildingspy/io/postprocess.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python
 
 
-class Plotter:
+from __future__ import division
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
+class Plotter(object):
     """
        This class contains static methods that can be used to create plots.
        For an example of a simple plot, see also the example
@@ -49,7 +54,7 @@ class Plotter:
         # If the last points are for the same time stamp, we remove them from the interpolation
         iMax = len(t)-1
         maxT=max(t)
-        dT = (maxT-min(t))/float(iMax)
+        dT = old_div((maxT-min(t)),float(iMax))
         while t[iMax] <= t[iMax-1]:
             iMax = iMax-1
 
@@ -200,7 +205,7 @@ class Plotter:
         # Make equidistant grid for the whole simulation period, such as 0, 1, ... 47
         # for two days
         tMax=max(t)
-        tGrid=np.linspace(0, tMax-increment, num=round(tMax/increment))
+        tGrid=np.linspace(0, tMax-increment, num=round(old_div(tMax,increment)))
 
         # Interpolate to hourly time stamps
         yGrid=Plotter.interpolate(tGrid, t, y)
@@ -212,7 +217,7 @@ class Plotter:
 
         tMaxPlot = nIncrement
         yStacked=np.reshape(yPer, (-1, tMaxPlot))
-        plt.boxplot(yStacked, positions=range(tMaxPlot),
+        plt.boxplot(yStacked, positions=list(range(tMaxPlot)),
                     notch=notch,
                     sym=sym, vert=vert, whis=whis,
                     widths=widths,

--- a/buildingspy/io/postprocess.py
+++ b/buildingspy/io/postprocess.py
@@ -5,7 +5,6 @@ from __future__ import division
 from builtins import str
 from builtins import range
 from builtins import object
-from past.utils import old_div
 class Plotter(object):
     """
        This class contains static methods that can be used to create plots.
@@ -54,7 +53,7 @@ class Plotter(object):
         # If the last points are for the same time stamp, we remove them from the interpolation
         iMax = len(t)-1
         maxT=max(t)
-        dT = old_div((maxT-min(t)),float(iMax))
+        dT = (maxT-min(t))/float(iMax)
         while t[iMax] <= t[iMax-1]:
             iMax = iMax-1
 
@@ -205,7 +204,7 @@ class Plotter(object):
         # Make equidistant grid for the whole simulation period, such as 0, 1, ... 47
         # for two days
         tMax=max(t)
-        tGrid=np.linspace(0, tMax-increment, num=round(old_div(tMax,increment)))
+        tGrid=np.linspace(0, tMax-increment, num=round(tMax/increment))
 
         # Interpolate to hourly time stamps
         yGrid=Plotter.interpolate(tGrid, t, y)

--- a/buildingspy/io/reporter.py
+++ b/buildingspy/io/reporter.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 
-class Reporter:
+from builtins import object
+class Reporter(object):
     ''' Class that is used to report errors.
     '''
 

--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -2,6 +2,11 @@
 
 
 from __future__ import print_function
+from __future__ import division
+from builtins import str
+from builtins import range
+from builtins import object
+from past.utils import old_div
 class Simulator(object):
     """Class to simulate a Modelica model.
 
@@ -188,7 +193,7 @@ class Simulator(object):
            >>> s.getParameters()
            [('valve.m_flow_nominal', 0.1), ('PID.k', 1.0)]
         '''
-        return self._parameters_.items()
+        return list(self._parameters_.items())
 
     def getOutputDirectory(self):
         '''Returns the name of the output directory.
@@ -802,7 +807,7 @@ end if;
                             pro.kill()
                     else:
                         if self._showProgressBar:
-                            fractionComplete = float(elapsedTime)/float(timeout)
+                            fractionComplete = old_div(float(elapsedTime),float(timeout))
                             self._printProgressBar(fractionComplete)
 
             else:
@@ -874,7 +879,7 @@ end if;
                 return repr(arg)
         dec = list()
 
-        for k, v in self._parameters_.items():
+        for k, v in list(self._parameters_.items()):
             # Dymola requires vectors of parameters to be set in the format
             # p = {1, 2, 3} rather than in the format of python arrays, which
             # is p = [1, 2, 3].
@@ -919,7 +924,7 @@ end if;
         actual_res = Reader(os.path.join(self._outputDir_,
                               self._simulator_['resultFile'])+'.mat',
                               'dymola')
-        for key, value in self._parameters_.iteritems():
+        for key, value in self._parameters_.items():
             if isinstance(value, list): # lists
                 for index, val in enumerate(value):
                     key_string = key + '['+ str(index+1) + ']'

--- a/buildingspy/simulate/Simulator.py
+++ b/buildingspy/simulate/Simulator.py
@@ -6,7 +6,6 @@ from __future__ import division
 from builtins import str
 from builtins import range
 from builtins import object
-from past.utils import old_div
 class Simulator(object):
     """Class to simulate a Modelica model.
 
@@ -807,7 +806,7 @@ end if;
                             pro.kill()
                     else:
                         if self._showProgressBar:
-                            fractionComplete = old_div(float(elapsedTime),float(timeout))
+                            fractionComplete = float(elapsedTime)/float(timeout)
                             self._printProgressBar(fractionComplete)
 
             else:

--- a/buildingspy/tests/test_development_error_dictionary.py
+++ b/buildingspy/tests/test_development_error_dictionary.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from builtins import range
 import unittest
 
 class Test_development_error_dictionary(unittest.TestCase):

--- a/buildingspy/tests/test_development_refactor.py
+++ b/buildingspy/tests/test_development_refactor.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from builtins import range
 import unittest
 
 class Test_development_refactor(unittest.TestCase):

--- a/buildingspy/tests/test_development_regressiontest.py
+++ b/buildingspy/tests/test_development_regressiontest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from builtins import range
 import unittest
 import os
 

--- a/buildingspy/tests/test_io_postprocess.py
+++ b/buildingspy/tests/test_io_postprocess.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+from builtins import map
+from builtins import range
 import unittest
 from buildingspy.io.postprocess import Plotter
 import numpy.testing
@@ -14,17 +16,17 @@ class Test_io_Plotter(unittest.TestCase):
         Tests the :mod:`buildingspy.io.Plotter.interpolate`
         function.
         '''
-        t10 = range(10)
-        t100 = range(100)
+        t10 = list(range(10))
+        t100 = list(range(100))
         f = lambda x: 10+2*x
-        y10  = map(f, t10)
-        y100 = map(f, t100)
+        y10  = list(map(f, t10))
+        y100 = list(map(f, t100))
         y10Int = Plotter.interpolate(t10, t100, y100)
         numpy.testing.assert_allclose(y10, y10Int)
         # Add one more element to t100. This emulates an event
         # at t=10, in which case dymola adds two points
         t100.append(10)
-        y100=map(f, sorted(t100))
+        y100=list(map(f, sorted(t100)))
         y10Int = Plotter.interpolate(t10, sorted(t100), y100)
         numpy.testing.assert_allclose(y10, y10Int)
 
@@ -44,7 +46,7 @@ class Test_io_Plotter(unittest.TestCase):
         (tP, yP) = Plotter.convertToPeriodic(10, t, y)
         # Test whether the time vector is periodic
         for i in range(10):
-            numpy.testing.assert_allclose(tP[i*10:(i+1)*10], range(10))
+            numpy.testing.assert_allclose(tP[i*10:(i+1)*10], list(range(10)))
         # Test whether y remains unchanged
         numpy.testing.assert_allclose(y, yP)
         # Should raise an exception of t[0] != 0


### PR DESCRIPTION
This is for #94, it is the output from `futurize --stage2 -w *.py`,
with some manual tweaks: old_div was not used, true float div was used everywhere.

`make doctest` still passes on Python 2, and still fails in Python 3.
For testing, use `python2` or `python3` instead of just `python` in the makefile.
`make unittest` fails for me before and after.

This PR adds some new imports from the pip installable package `future`, 
so it will add `future` to the dependencies (for Python 2 users).
ToDo:  mention future as dependency in  setup.py
http://python-future.org/compatible_idioms.html#setup
http://python-future.org/compatible_idioms.html#range

This PR also covers everything that was proposed in #93.
Search for `iteritems` in #93 and here:
http://python-future.org/compatible_idioms.html#iterating-through-dict-keys-values-items