### PR TITLE
Travis CI

### DIFF
--- a/.matplotlibrc
+++ b/.matplotlibrc
@@ -1,0 +1,1 @@
+backend : Agg

--- a/.matplotlibrc
+++ b/.matplotlibrc
@@ -1,1 +1,0 @@
-backend : Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+# command to install dependencies
+install:
+  - pip install future pytidylib gitpython
+# command to run tests
+script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - pip install --only-binary=numpy,scipy future scipy pytidylib gitpython
+  - pip install --only-binary=numpy,scipy numpy scipy future pytidylib gitpython
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 # command to install dependencies
 before_install:
   - sudo apt-get python-scipy
-- pip install scipy
+  - pip install scipy
 install:
   - pip install future gitpython pytidylib
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - - sudo apt-get build-dep python-scipy
+  - sudo apt-get build-dep python-scipy
   - pip install scipy
 install:
   - pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - sudo apt-get python-scipy tidy
+  - sudo apt-get build-deb python-scipy tidy
   - pip install scipy
 install:
   - pip install future gitpython pytidylib

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ python:
 # command to install dependencies
 before_install:
   - sudo apt-get build-dep python-scipy
-  - pip install scipy
+  - pip install numpy scipy matplotlib
 install:
-  - pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
   - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
-before_install:
-  - sudo apt-get python-scipy
-  - pip install scipy
 install:
+  - pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
   - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ notifications:
 # command to install dependencies
 install:
   - pip install --upgrade pip setuptools wheel
-  - pip install --only-binary=numpy,scipy numpy scipy
+  - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
   - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ addons:
     - python-scipy
     - tidy
 install:
-  - pip install scipy future gitpython pytidylib
+  - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,9 @@ python:
 notifications:
   email: false
 # command to install dependencies
-addons:
-  apt:
-    packages:
-    - python-scipy
-    - tidy
-    - libblas-dev
-    - liblapack-dev
-    - gfortran
 install:
-  - pip install scipy future gitpython pytidylib
+  - pip install --upgrade pip setuptools wheel
+  - pip install --only-binary=numpy,scipy numpy scipy
+  - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,10 @@ addons:
     packages:
     - python-scipy
     - tidy
+    - libblas-dev
+    - liblapack-dev
+    - gfortran
 install:
-  - pip install future gitpython pytidylib
+  - pip install scipy future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: python
 python:
   - "2.7"
   - "3.5"
+notifications:
+  email: false
 # command to install dependencies
 addons:
   apt:
     packages:
     - python-scipy
     - tidy
-- graphviz
 install:
   - pip install future gitpython pytidylib
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - pip install future pytidylib gitpython
+  - pip install future scipy pytidylib gitpython
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - sudo apt-get build-dep python-scipy
-  - pip install numpy scipy matplotlib
+  - sudo apt-get python-scipy tidy
+  - pip install scipy
 install:
   - pip install future gitpython pytidylib
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_install:
   - sudo apt-get python-scipy
 - pip install scipy
 install:
-  - pip install future pytidylib gitpython
+  - pip install future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
 notifications:
   email: false
 # command to install dependencies
+addons:
+  apt:
+    packages:
+    - tidy
 install:
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ install:
 script: 
 # - make doctest
   - python buildingspy/tests/test_development_error_dictionary.py
-  - python buildingspy/tests/test_development_regressiontest.py
+  - python buildingspy/tests/test_development_merger.py
+  - python buildingspy/tests/test_development_refactor.py
+# - python buildingspy/tests/test_development_regressiontest.py
   - python buildingspy/tests/test_development_Validator.py
+# - python buildingspy/tests/test_examples_dymola.py
+  - python buildingspy/tests/test_io_outputfile.py
   - python buildingspy/tests/test_io_postprocess.py
+# - python buildingspy/tests/test_simulate_Simulator.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,6 @@ addons:
     - python-scipy
     - tidy
 install:
-  - pip install future gitpython pytidylib
+  - pip install scipy future gitpython pytidylib
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
-before_install:
-  - sudo apt-get install -y python-scipy tidy
+addons:
+  apt:
+    packages:
+    - python-scipy
+    - tidy
+- graphviz
 install:
   - pip install future gitpython pytidylib
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
+before_install:
+  - - sudo apt-get build-dep python-scipy
+  - pip install scipy
 install:
   - pip install --user numpy scipy matplotlib ipython jupyter pandas sympy nose
   - pip install future gitpython pytidylib

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - pip install future scipy pytidylib gitpython
+  - pip install --only-binary=numpy,scipy future scipy pytidylib gitpython
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,6 @@ install:
   - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
   - pip install future gitpython pytidylib
 # command to run tests
-script: make doctest
+script: 
+#- make doctest
+  - python buildingspy/tests/test_development_Validator.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
 script: 
 # - make doctest
   - python buildingspy/tests/test_development_error_dictionary.py
-  - python buildingspy/tests/test_development_merger.py
+# - python buildingspy/tests/test_development_merger.py
   - python buildingspy/tests/test_development_refactor.py
 # - python buildingspy/tests/test_development_regressiontest.py
   - python buildingspy/tests/test_development_Validator.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,8 @@ install:
   - pip install .
 # command to run tests
 script: 
-#- make doctest
+# - make doctest
+  - python buildingspy/tests/test_development_error_dictionary.py
+  - python buildingspy/tests/test_development_regressiontest.py
   - python buildingspy/tests/test_development_Validator.py
+  - python buildingspy/tests/test_io_postprocess.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - pip install --upgrade pip setuptools wheel
   - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
   - pip install future gitpython pytidylib
+  - pip install .
 # command to run tests
 script: 
 #- make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ python:
   - "2.7"
   - "3.5"
 # command to install dependencies
+before_install:
+  - sudo apt-get python-scipy
+- pip install scipy
 install:
-  - pip install --only-binary=numpy,scipy numpy scipy future pytidylib gitpython
+  - pip install future pytidylib gitpython
 # command to run tests
 script: make doctest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - sudo apt-get -qq update
   - sudo apt-get install -y python-scipy tidy
 install:
   - pip install future gitpython pytidylib

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - sudo apt-get build-deb python-scipy
-  - pip install scipy
+  - sudo apt-get -qq update
+  - sudo apt-get install -y python-scipy tidy
 install:
   - pip install future gitpython pytidylib
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.5"
 # command to install dependencies
 before_install:
-  - sudo apt-get build-deb python-scipy tidy
+  - sudo apt-get build-deb python-scipy
   - pip install scipy
 install:
   - pip install future gitpython pytidylib


### PR DESCRIPTION
This is for #94.

Here is a `.travis.yml` file,
containing the configuration to run some of the unit tests with Travis CI on Python 2.7 and 3.5
In addition, Travis has to be configured to use the environment variable `MPLBACKEND` with value `agg` to avoid a matplotlib error about missing $DISPLAY environment variable.

This script will not run the doctest and only some of the unittests,
because Travis CI does not have a Modelica tool installed,
and some unit tests still fail on Python 3.5.

I needed a couple of commits to figure out the correct configuration, but this version works for me:
https://travis-ci.org/thorade/BuildingsPy
When merging, use `Squash and merge` to make it one single good-looking commit.