### PR TITLE
shallow clone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
 #
 # run selected unittests
   - python buildingspy/tests/test_development_error_dictionary.py
-# - python buildingspy/tests/test_development_merger.py
+  - python buildingspy/tests/test_development_merger.py
   - python buildingspy/tests/test_development_refactor.py
 # - python buildingspy/tests/test_development_regressiontest.py
   - python buildingspy/tests/test_development_Validator.py

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -39,7 +39,7 @@ class Annex60(object):
             try:
                 t.Tester().isValidLibrary(lib_home)
             except ValueError as e:
-                s = "{}\n    Did not do anything.".format(e.message)
+                s = "{!s}\n    Did not do anything.".format(e.message)
                 raise ValueError(s)
 
         isValidLibrary(annex60_dir)

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -92,12 +92,11 @@ class Annex60(object):
 
         # Read source file, store the lines and update the content of the lines
         with open(source_file, 'r') as f_sou:
-        lines = list()
-        for _, lin in enumerate(f_sou):
-            for ori, new in rep.items():
-                lin = str.replace(lin, ori, new)
-            lines.append(lin)
-        f_sou.close
+            lines = list()
+            for _, lin in enumerate(f_sou):
+                for ori, new in rep.items():
+                    lin = str.replace(lin, ori, new)
+                lines.append(lin)
         # Write the lines to the new file
         f_des = open(destination_file, 'w')
         f_des.writelines(lines)

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -12,7 +12,6 @@ from __future__ import print_function
 #from __future__ import unicode_literals
 
 from builtins import object
-from builtins import str
 
 class Annex60(object):
     ''' Class that merges a Modelica library with the `Annex60` library.

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -39,7 +39,7 @@ class Annex60(object):
             try:
                 t.Tester().isValidLibrary(lib_home)
             except ValueError as e:
-                s = "{!s}\n    Did not do anything.".format(e.message)
+                s = "{!s}\n    Did not do anything.".format(e.args[0])
                 raise ValueError(s)
 
         isValidLibrary(annex60_dir)

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -91,7 +91,7 @@ class Annex60(object):
                         "Buildings.HeatTransfer.Sources.FixedTemperature"})
 
         # Read source file, store the lines and update the content of the lines
-        f_sou = open(source_file, 'r')
+        with open(source_file, 'r') as f_sou:
         lines = list()
         for _, lin in enumerate(f_sou):
             for ori, new in rep.items():

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 #from __future__ import unicode_literals
 
 from builtins import object
+from builtins import str
 
 class Annex60(object):
     ''' Class that merges a Modelica library with the `Annex60` library.
@@ -78,7 +79,6 @@ class Annex60(object):
         :param source_file: Name of the file to be copied.
         :param destination_file: Name of the new file.
         """
-        import string
 
         rep = {self._src_library_name:
                self._new_library_name}
@@ -96,7 +96,7 @@ class Annex60(object):
         lines = list()
         for _, lin in enumerate(f_sou):
             for ori, new in rep.items():
-                lin = string.replace(lin, ori, new)
+                lin = str.replace(lin, ori, new)
             lines.append(lin)
         f_sou.close
         # Write the lines to the new file

--- a/buildingspy/tests/test_development_merger.py
+++ b/buildingspy/tests/test_development_merger.py
@@ -34,9 +34,9 @@ class Test_development_merger_Annex60(unittest.TestCase):
             # Clone the libraries
             print("Cloning Buildings repository. This may take a while.")
             print("Dir is {}".format(self._repDir))
-            Repo.clone_from("https://github.com/lbl-srg/modelica-buildings", os.path.join(self._repDir, "modelica-buildings"))
+            Repo.clone_from("https://github.com/lbl-srg/modelica-buildings", os.path.join(self._repDir, "modelica-buildings"), depth=5)
             print("Cloning Annex 60 repository. This may take a while.")        
-            Repo.clone_from("https://github.com/iea-annex60/modelica-annex60", os.path.join(self._repDir, "modelica-annex60"))
+            Repo.clone_from("https://github.com/iea-annex60/modelica-annex60", os.path.join(self._repDir, "modelica-annex60"), depth=5)
             print("Finished cloning.")
             
         else:


### PR DESCRIPTION
This should close #119.

The command
```
python buildingspy/tests/test_development_merger.py
```
works for me on Linux, before and after.

On Windows 10 it failed before and after with the error message
```
error: unable to create file Buildings/Resources/Scripts/OpenModelica/compareVars/Buildings.Experimental.DistrictHeatingCooling.SubStations.VaporCompression.Validation.HeatingCoolingHotwaterTimeSeries_dT.mos: Filename too long
```