### PR TITLE
Test ci py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+env:
+  - MPLBACKEND=agg
 
 notifications:
   email: false
@@ -11,14 +16,9 @@ git:
 services:
   - docker
 
-# Enable system site packages in virtualenv so BuildingsPy sees scipy and matplotlib
-virtualenv:
-  system_site_packages: true
-
 before_install:
   - sudo mv BuildingsPy/buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
   - sudo chmod +x /usr/local/bin/dymola
-  - sudo apt-get install -qq python-numpy python-scipy python-matplotlib
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   - docker pull "$DOCKER_USERNAME"/travis_ubuntu-1604_dymola-2017fd01-x86-64
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+
 env:
   - MPLBACKEND=agg
 
@@ -15,12 +16,23 @@ git:
 
 services:
   - docker
-
+  
+addons:
+  apt:
+    packages:
+    - tidy
+    
 before_install:
   - sudo mv BuildingsPy/buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
   - sudo chmod +x /usr/local/bin/dymola
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   - docker pull "$DOCKER_USERNAME"/travis_ubuntu-1604_dymola-2017fd01-x86-64
+
+install:
+  - pip install --upgrade pip setuptools wheel
+  - pip install --only-binary=numpy,scipy,matplotlib numpy scipy matplotlib
+  - pip install future gitpython pytidylib
+  - pip install .
 
 # Execute tests
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ git:
 
 services:
   - docker
-  
+
 addons:
   apt:
     packages:
     - tidy
-    
+
 before_install:
   - sudo mv buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
   - sudo chmod +x /usr/local/bin/dymola

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ addons:
     - tidy
     
 before_install:
-  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
-  - docker pull "$DOCKER_USERNAME"/travis_ubuntu-1604_dymola-2017fd01-x86-64
   - sudo mv buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
   - sudo chmod +x /usr/local/bin/dymola
+  - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
+  - docker pull "$DOCKER_USERNAME"/travis_ubuntu-1604_dymola-2017fd01-x86-64
 
 install:
   - pip install --upgrade pip setuptools wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ addons:
     - tidy
     
 before_install:
-  - sudo mv BuildingsPy/buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
-  - sudo chmod +x /usr/local/bin/dymola
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD";
   - docker pull "$DOCKER_USERNAME"/travis_ubuntu-1604_dymola-2017fd01-x86-64
+  - sudo mv buildingspy/tests/MyModelicaLibrary/Resources/Scripts/travis/usr/local/bin/dymola /usr/local/bin/
+  - sudo chmod +x /usr/local/bin/dymola
 
 install:
   - pip install --upgrade pip setuptools wheel
@@ -36,4 +36,4 @@ install:
 
 # Execute tests
 script:
-  - (cd BuildingsPy && make doctest unittest)
+  - make doctest unittest

--- a/buildingspy/fmi/__init__.py
+++ b/buildingspy/fmi/__init__.py
@@ -38,34 +38,34 @@ def get_dependencies(fmu_file_name):
        >>> import buildingspy.fmi as f
        >>> fmu_name=os.path.join("buildingspy", "tests", "fmi", "IntegratorGain.fmu")
        >>> d=f.get_dependencies(fmu_name)
-       >>> print(json.dumps(d, indent=2))
+       >>> print(json.dumps(d, indent=2, sort_keys=True))
        {
-         "Outputs": {
-           "y1": [
-             "x"
-           ], 
-           "EventCounter": [], 
-           "y2": [
+         "Derivatives": {
+           "der(x)": [
              "u"
-           ], 
-           "CPUtime": []
+           ]
          }, 
          "InitialUnknowns": {
+           "CPUtime": [], 
+           "EventCounter": [], 
+           "der(x)": [
+             "u"
+           ], 
            "y1": [
              "x"
            ], 
-           "EventCounter": [], 
            "y2": [
              "k", 
              "u"
-           ], 
-           "der(x)": [
-             "u"
-           ], 
-           "CPUtime": []
+           ]
          }, 
-         "Derivatives": {
-           "der(x)": [
+         "Outputs": {
+           "CPUtime": [], 
+           "EventCounter": [], 
+           "y1": [
+             "x"
+           ], 
+           "y2": [
              "u"
            ]
          }


### PR DESCRIPTION
`system_site _packages` should only be used if necessary:
https://docs.travis-ci.com/user/languages/python/#Travis-CI-Uses-Isolated-virtualenvs
But here it is not necessary, because scipy and numpy are easily installed via pip.
By using `only-binary` it is as quick as apt-get, but it will work on any Python version.

MPLBACKEND is for matplotlib.

Does this Pull Request trigger a build?
https://travis-ci.org/lbl-srg/BuildingsPy/pull_requests
docker will only work inside this repository, not on forks.