### PR TITLE
Added option to pass packages in notation A.{B,C}

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -469,7 +469,37 @@ class Tester(object):
                 print("*** Warning: Excluded file {} from the regression tests.".format(fileName))
                 return False
         else:
-            False
+            return False
+
+    @staticmethod
+    def expand_packages(packages):
+        '''
+        Expand the ``packages`` from the form
+        ``A.{B,C}`` and return ``A.B,A.C``
+        :param: packages: A list of packages
+        '''
+        ids = packages.find('{')
+        if ids < 0:
+            # This has no curly bracket notation
+            return packages
+
+        ide = packages.find('}')
+
+        # Make some simple test for checking the string format
+        if ide-1 <= ids:
+            raise ValueError("String '{}' is wrong formatted".format(packages))
+
+        # Get text before the curly brackets
+        pre = packages[0:ids]
+        # Get text inside the curly brackets
+        in_bra = packages[ids+1:ide]
+        entries = in_bra.split(',')
+        # Add the start to the entries
+        pac = []
+        for ele in entries:
+            pac.append("{}{}".format(pre, ele))
+        ret = ",".join(pac)
+        return ret.replace(' ','')
 
     def setSinglePackage(self, packageName):
         '''
@@ -495,7 +525,9 @@ class Tester(object):
         # Create a list of packages, unless packageName is already a list
         packages = list()
         if ',' in packageName:
-            packages = packageName.split(',')
+            # First, split packages in case they are of the form Building.{Examples, Fluid}
+            expanded_packages = self.expand_packages(packageName)
+            packages = expanded_packages.split(',')
         else:
             packages.append(packageName)
         # Inform the user that not all tests are run, but don't add to warnings

--- a/buildingspy/tests/test_development_regressiontest.py
+++ b/buildingspy/tests/test_development_regressiontest.py
@@ -205,6 +205,35 @@ class Test_regressiontest_Tester(unittest.TestCase):
         rt.setLibraryRoot(myMoLib)
         rt.setDataDictionary()
 
+    def test_expand_packages(self):
+        import buildingspy.development.regressiontest as r
+
+        self.assertEqual("A.B",
+           r.Tester.expand_packages("A.B"))
+        self.assertEqual("A.B,A.C",
+           r.Tester.expand_packages("A.{B,C}"))
+        self.assertEqual("A.B.xy,A.B.xy.z",
+           r.Tester.expand_packages("A.B.{xy,xy.z}"))
+
+        # Add spaces
+        self.assertEqual("A.B,A.C",
+           r.Tester.expand_packages("A.{B, C}"))
+        self.assertEqual("A.B,A.C",
+           r.Tester.expand_packages("A.{ B , C }"))
+        self.assertEqual("A.B.xy,A.B.xy.z",
+           r.Tester.expand_packages("A.B.{xy, xy.z}"))
+        self.assertEqual("A.B.xy,A.B.xy.z",
+           r.Tester.expand_packages("A.B.{ xy, xy.z}"))
+        self.assertEqual("A.B.xy,A.B.xy.z",
+           r.Tester.expand_packages("A.B.{ xy , xy.z }"))
+
+        self.assertRaises(ValueError, \
+            r.Tester.expand_packages, "AB{")
+        self.assertRaises(ValueError, \
+            r.Tester.expand_packages, "AB{}")
+        self.assertRaises(ValueError, \
+            r.Tester.expand_packages, "AB}a{")
+
 if __name__ == '__main__':
     unittest.main()
     #selection = unittest.TestSuite()


### PR DESCRIPTION
Added option to pass for regression tests the package list in notation such as `A.{B, C, D}`.