### PR TITLE
fix reference results acceptance

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -1226,7 +1226,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             sys.stdout.write("             for %s\n" % refFilNam)
             sys.stdout.write("             Accept new results?\n")
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
-                ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 # update the flag
                 updateReferenceData = True
@@ -1324,7 +1324,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
                     foundError = True
                     while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                         print("             Accept new results and update reference file in library?")
-                        ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                        ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                     if ans == "y" or ans == "Y":
                         # Write results to reference file
                         updateReferenceData = True
@@ -1432,7 +1432,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             self._figSize=gcf.get_size_inches()
 
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
-                ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 # update the flag
                 updateReferenceData = True
@@ -1489,7 +1489,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             print("*** Warning: Reference file {} does not yet exist.".format(reference_file_name))
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                 print("             Create new file?")
-                ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                 self._reporter.writeWarning("*** Warning: Wrote new reference file %s." %
@@ -1512,7 +1512,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             if found_differences:
                 while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                     print("             Rewrite file?")
-                    ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                    ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                 if ans == "y" or ans == "Y":
                     self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                     self._reporter.writeWarning("*** Warning: Rewrote reference file %s due to new FMU statistics." %
@@ -1525,7 +1525,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
             print("*** Warning: Reference file {} has no FMU statistics.".format(reference_file_name))
             while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                 print("             Rewrite file?")
-                ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
             if ans == "y" or ans == "Y":
                 self._writeReferenceResults(abs_ref_fil_nam, None, y_tra)
                 self._reporter.writeWarning("*** Warning: Rewrote reference file %s as the old one had no FMU statistics." %
@@ -1659,7 +1659,7 @@ len(yNew)    = %d.""" % (filNam, varNam, len(tGriOld), len(tGriNew), len(yNew))
                         print("*** Warning: Reference file {} does not yet exist.".format(refFilNam))
                         while not (ans == "n" or ans == "y" or ans == "Y" or ans == "N"):
                             print("             Create new file?")
-                            ans = eval(input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): "))
+                            ans = input("             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
                         if ans == "y" or ans == "Y":
                             updateReferenceData = True
                     if updateReferenceData:    # If the reference data of any variable was updated


### PR DESCRIPTION
Commit b369acc7a5ef6fd95e86dd0529eded2f14cd4da7 (part of #140 and #94) broke the input for accepting reference results.

Python 2 knows `raw_input` and `input`, where `raw_input` always returns a string and `input` is identical to  `eval(raw_input)`.

Python 3 only knows `input` and it behaves like `raw_input` did on Py2, because a string is what most people wanted and using eval is a security problem. 

The futurize script does not know whether the `eval` step was really needed and adds it, but that does not work here: it is treating the input `Y` as a variable and tries to evaluate it, but there is no variable named `y` so one gets a `NameError: name Y is not defined`.

As we really wanted a string anyway, `raw_input` would have been correct in Py2 and `input` would have been correct on Python 3. As we use the future package and have the line `from builtins import *` in all scripts, we should use `input` (as in Py3).

So, this PR partly reverts b369acc7a5ef6fd95e86dd0529eded2f14cd4da7 and removes the `eval` again. 
Unittests do not cover this part, so to really test this PR, one has to run regressiontest.py locally for a case where reference results have changed to trigger the prompt for input.
The version as in the PR works for me on Python 2.7 (on Linux) and 3.4 (on Windows)

Also read:
http://stackoverflow.com/a/15129556/874701
http://python-future.org/compatible_idioms.html#raw-input

Another sidenote:
Some IPython notebook versions had problems to read input! 
https://github.com/ipython/ipython/issues/3990
To fix this, upgrade to the latest version of IPython or run the scripts from the console.