### PR TITLE
only 1 positional argument for json.dumps

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -2351,8 +2351,11 @@ getErrorString();
                         retVal = 1
                 # Dump an array of testCase objects
                 # dump to a string first using json.dumps instead of json.dump
-                json_string = json.dumps({"testCase": stat}, indent=4,
-                                         separators=(',', ': '), ensure_ascii=False)
+                json_string = json.dumps({"testCase": stat},
+                                         ensure_ascii=False,
+                                         indent=4,
+                                         separators=(',', ': '),
+                                         sort_keys=True)
                 logFil.write(json_string)
 
         # check logfile if omc

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -2351,7 +2351,7 @@ getErrorString();
                         retVal = 1
                 # Dump an array of testCase objects
                 # dump to a string first using json.dumps instead of json.dump
-                json_string = json.dumps({"testCase": stat}, logFil, indent=4,
+                json_string = json.dumps({"testCase": stat}, indent=4,
                                          separators=(',', ': '), ensure_ascii=False)
                 logFil.write(json_string)
 


### PR DESCRIPTION
dump writes to the logFil directly,
while dumps writes into a string, and then we use logFil.write(string)

this is a correction of
https://github.com/lbl-srg/BuildingsPy/commit/c80adf719617ff99811f6e0d5fd2b444ff2d1e03?w=1

detected, because Py3.6 allows only 1 positional argument for json.dumps (all other arguments have to be kwargs).