### PR TITLE
added default values for Evaluate, EfficientMinorEvents and CompileWith64

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -2042,6 +2042,10 @@ Modelica.Utilities.Streams.print("        \"numerical Jacobians\"  : " + String(
                 if self._modelica_tool == 'dymola':
                     # Disable parallel computing as this can give slightly different results.
                     runFil.write('Advanced.ParallelizeCode = false;\n')
+                    # Default values for options that can give slightly different results.
+                    runFil.write('Evaluate=false;\n')
+                    runFil.write('Advanced.CompileWith64=2;\n')
+                    runFil.write('Advanced.EfficientMinorEvents=false;\n')
                     # Set the pedantic Modelica mode
                     if self._pedanticModelica:
                         runFil.write('Advanced.PedanticModelica = true;\n')


### PR DESCRIPTION
for #201

the influence on the IBPSA reference results can be checked here: https://travis-ci.org/ibpsa/modelica-ibpsa/builds/382015445 

I still have to process the results when the tests complete.