### PR TITLE
Issue371 pyfunnel dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - python -m pip install --upgrade pip
 
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.txt --extra-index-url=https://test.pypi.org/simple/
   - pip install .
 
 # Execute tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ before_install:
   - python -m pip install --upgrade pip
 
 install:
-  - pip install -r requirements.txt --extra-index-url=https://test.pypi.org/simple/
+  - pip install -r requirements.txt
   - pip install .
 
 # Execute tests

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -20,10 +20,11 @@ To install the latest development version, run
 
    python3 -m pip install --user buildingspy@git+https://github.com/lbl-srg/buildingspy.git@master
 
-
-To clone BuildingsPy for development, together with its dependency ``funnel`` (https://github.com/lbl-srg/funnel), run
+To clone BuildingsPy for development, run
 
 .. parsed-literal::
 
    git clone git@github.com:lbl-srg/BuildingsPy.git
-   python3 -m pip install --user pyfunnel@git+https://github.com/lbl-srg/funnel.git@v0.1.0
+   cd BuildingsPy
+   python3 -m pip install --user -r requirements.txt
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gitpython==2.1.15; python_version~='2.7'
 pytidylib==0.3.2
 simplejson==3.17.0
 six==1.14.0
-pyfunnel==0.2.1
+pyfunnel==0.2.2
 
 # For documentation and testing.
 setuptools==46.0.0; python_version>='3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gitpython==2.1.15; python_version~='2.7'
 pytidylib==0.3.2
 simplejson==3.17.0
 six==1.14.0
-pyfunnel==0.2.0
+pyfunnel==0.2.1
 
 # For documentation and testing.
 setuptools==46.0.0; python_version>='3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ gitpython==2.1.15; python_version~='2.7'
 pytidylib==0.3.2
 simplejson==3.17.0
 six==1.14.0
-pyfunnel@git+https://github.com/lbl-srg/funnel.git@v0.1.0
+pyfunnel==0.2.0
 
 # For documentation and testing.
 setuptools==46.0.0; python_version>='3.6'

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'scipy>=1.1',
         'simplejson>=3.14',
         'six>=1.11',
-        'pyfunnel@git+https://github.com/lbl-srg/funnel.git@v0.1.0',
+        'pyfunnel>=0.2',
     ],
     packages=[
         MAIN_PACKAGE,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'scipy>=1.1',
         'simplejson>=3.14',
         'six>=1.11',
-        'pyfunnel>=0.2.1',
+        'pyfunnel>=0.2.2',
     ],
     packages=[
         MAIN_PACKAGE,

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'scipy>=1.1',
         'simplejson>=3.14',
         'six>=1.11',
-        'pyfunnel>=0.2',
+        'pyfunnel>=0.2.1',
     ],
     packages=[
         MAIN_PACKAGE,


### PR DESCRIPTION
This closes #370 and #371 trough funnel [#44](https://github.com/lbl-srg/funnel/pull/44), [#46](https://github.com/lbl-srg/funnel/pull/46) and [#48](https://github.com/lbl-srg/funnel/pull/48).

Please note that installation instructions for development (in `doc/source/install.rst`) have been updated to use `requirements.txt` instead of manually installing pyfunnel.

```rst
To clone BuildingsPy for development, run

.. parsed-literal::

   git clone git@github.com:lbl-srg/BuildingsPy.git
   cd BuildingsPy
   python3 -m pip install --user -r requirements.txt
```