### PR TITLE
Fixed race condition

### DIFF
--- a/buildingspy/io/reporter.py
+++ b/buildingspy/io/reporter.py
@@ -28,7 +28,12 @@ class Reporter(object):
         """
         import os
         if os.path.isfile(self._logFil):
-            os.remove(self._logFil)
+            # The try-except below guards against a race condition if multiple
+            # processes start and they try to delete the file at the same time.
+            try:
+                os.remove(self._logFil)
+            except FileNotFoundError:
+                print(f"Failed to remove {self._logFil} as it no longer exists.")
 
     def logToFile(self, log=True):
         """ Function to log the standard output and standard error stream to a file.


### PR DESCRIPTION
This fixes a race condition that occurred when running:
```python
import os
from multiprocessing import Pool

from buildingspy.simulate.Dymola import Simulator
from buildingspy.io.outputfile import Reader
#Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating
cases = [ \
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Radau",  "tol": 1E-6},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Radau",  "tol": 1E-7},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Radau",  "tol": 1E-8},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Cvode",  "tol": 1E-6},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Cvode",  "tol": 1E-7},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Cvode",  "tol": 1E-8},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Lsodar", "tol": 1E-6},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Lsodar", "tol": 1E-7},
     {"model": "Buildings.ThermalZones.Detailed.Validation.SingleZoneFloorWithHeating", "solver": "Lsodar", "tol": 1E-8},
]

for cas in cases:
    resultFile = cas['model'].split(".")[-1] + ".mat"
    if os.path.exists(resultFile):
        os.remove(resultFile)

def simulate(cas):
    print(f"Starting {cas['model']} - {cas['solver']} - {cas['tol']}")
    s=Simulator(cas['model'], outputDirectory=f"{cas['solver']}-{cas['tol']}")
    s.setSolver(cas['solver'])
    s.addPostProcessingStatement("OutputCPUtime = true;")
    s.setTimeOut(10*60)
    s.showGUI(True)
    s.exitSimulator(False)
    s.simulate()

p = Pool(10)
print(p.map(simulate, cases))

for cas in cases:
    resultFile = cas['model'].split(".")[-1] + ".mat"
    if os.path.exists(resultFile):
        r=Reader(resultFile, "dymola")
        tCPU = r.max('CPUtime')
        print(f"{cas['model']} - {cas['solver']} - {cas['tol']} -- tCPU = {tCPU}")
    else:
        print(f"{cas['model']} - {cas['solver']} - {cas['tol']} -- Failed to simulate")
```
The error message was
```
multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "runWithBuildingsPy.py", line 26, in simulate
    s=Simulator(cas['model'], packagePath="Buildings")
  File "/home/mwetter/proj/ldrd/bie/modeling/github/lbl-srg/BuildingsPy/buildingspy/simulate/Dymola.py", line 49, in __init__
    'run_translate.mos', 'simulator.log', 'translator.log', 'dslog.txt'])
  File "/home/mwetter/proj/ldrd/bie/modeling/github/lbl-srg/BuildingsPy/buildingspy/simulate/base_simulator.py", line 80, in __init__
    self._reporter = reporter.Reporter(fileName=logFilNam)
  File "/home/mwetter/proj/ldrd/bie/modeling/github/lbl-srg/BuildingsPy/buildingspy/io/reporter.py", line 24, in __init__
    self.deleteLogFile()
  File "/home/mwetter/proj/ldrd/bie/modeling/github/lbl-srg/BuildingsPy/buildingspy/io/reporter.py", line 31, in deleteLogFile
    os.remove(self._logFil)
FileNotFoundError: [Errno 2] No such file or directory: './BuildingsPy.log'
"""

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "runWithBuildingsPy.py", line 35, in <module>
    print(p.map(simulate, cases))
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
FileNotFoundError: [Errno 2] No such file or directory: './BuildingsPy.log'

```