### PR TITLE
WIP: Custom path to reference results

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -430,6 +430,20 @@ class Tester(object):
         self._rootPackage = os.path.join(self._libHome, 'Resources', 'Scripts', 'Dymola')
         self.isValidLibrary(self._libHome)
 
+        self._set_up_reference_directory()
+
+
+    def _set_up_reference_directory(self):
+        """ Set up the directory for the reference results.
+
+        During initialization, ``self.dir_ref`` is either set to the default ``None``
+        or a custom directory path. For the default, the standard path at
+        ``self._libHome\\Resources\\ReferenceResults\\Dymola`` can only be set up after
+        ``self._libHome`` has been set. Otherwise, the originally passed custom
+        path is used. In both cases, the directory is created if it does not exist,
+        yet.
+        """
+
         if self.dir_ref is None:
             self.dir_ref = os.path.join(
                 self._libHome, 'Resources', 'ReferenceResults', 'Dymola'

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -257,14 +257,7 @@ class Tester(object):
         self._rootPackage = os.path.join(self._libHome, 'Resources', 'Scripts', 'Dymola')
 
         # Set the reference results directory
-        if dir_ref is None:
-            self.dir_ref = os.path.join(
-                self._libHome, 'Resources', 'ReferenceResults', 'Dymola'
-            )
-        else:
-            self.dir_ref = dir_ref
-        if not os.path.exists(self.dir_ref):
-            os.makedirs(self.dir_ref)
+        self.dir_ref = dir_ref
 
         # Set the tool
         if tool in ['dymola', 'omc', 'optimica', 'jmodelica']:
@@ -436,6 +429,13 @@ class Tester(object):
         self._libHome = os.path.abspath(rootDir)
         self._rootPackage = os.path.join(self._libHome, 'Resources', 'Scripts', 'Dymola')
         self.isValidLibrary(self._libHome)
+
+        if self.dir_ref is None:
+            self.dir_ref = os.path.join(
+                self._libHome, 'Resources', 'ReferenceResults', 'Dymola'
+            )
+        if not os.path.exists(self.dir_ref):
+            os.makedirs(self.dir_ref)
 
     def useExistingResults(self, dirs):
         """ This function allows to use existing results, as opposed to running a simulation.


### PR DESCRIPTION
For #393 : 

- Add option to specify a custom path for reference results so that we can also compare results to references outside the tested library
- If no custom path is given, the standard way of searching for/creating the reference result directory should behave as before.