### PR TITLE
Bump jinja2 from 2.11.1 to 2.11.3

### DIFF
--- a/buildingspy/CHANGES.txt
+++ b/buildingspy/CHANGES.txt
@@ -4,6 +4,10 @@ BuildingsPy Changelog
 Version 2.2.0, xxx, 2020 -- Release 2.2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - xxx
+- For unit tests, ignore zero-size linear and nonlinear equations when comparing statistics
+  (https://github.com/lbl-srg/BuildingsPy/issues/406)
+- For unit tests, changed warning to an error if start or end times differ from reference results
+  (https://github.com/lbl-srg/BuildingsPy/issues/404)
 - Corrected timeout handling in buildingspy.simulate.base_simulator.py
   (https://github.com/lbl-srg/BuildingsPy/issues/385)
 - Corrected class name lookup mechanism in buildingspy.development.refactor.move_class()

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -1590,7 +1590,7 @@ class Tester(object):
         :param filNam: File name, used for reporting.
         :param model_name: Model name, used for reporting.
         :return: A list with ``False`` if the results are not equal, and the time
-                 of the maximum error, and a warning message or `None`.
+                 of the maximum error, and a error message or `None`.
                  In case of errors, the time of the maximum error may by `None`.
         """
         try:
@@ -1606,7 +1606,7 @@ class Tester(object):
             elif len(t) == nPoi:
                 return t
             else:
-                s = ("While processing file {} for variable {}: the new time grid has {} points "
+                s = ("While processing file {} for variable {}: The new time grid has {} points "
                      "but it must have 2 or {} points.\n"
                      "Stop processing.\n").format(
                     filNam,
@@ -1618,8 +1618,8 @@ class Tester(object):
         # Check if the first and last time stamp are equal
         tolTim = 1E-3  # Tolerance for time
         if (abs(tOld[0] - tNew[0]) > tolTim) or abs(tOld[-1] - tNew[-1]) > tolTim:
-            warning = (
-                "While processing file {} for variable {}: different simulation time interval between "
+            error = (
+                "While processing file {} for variable {}: Different simulation time interval between "
                 "reference and test data.\n"
                 "Old reference points are for {} <= t <= {}\n"
                 "New reference points are for {} <= t <= {}\n").format(
@@ -1628,8 +1628,8 @@ class Tester(object):
             t_err_max = None
 
         if (abs(tOld[-1] - tNew[-1]) > 1E-5):
-            warning = (
-                "While processing file {} for variable {}: different end time between "
+            error = (
+                "While processing file {} for variable {}: Different end time between "
                 "reference and test data.\n"
                 "tNew = [{}, {}]\n"
                 "tOld = [{}, {}]\n").format(filNam, varNam, tNew[0], tNew[-1], tOld[0], tOld[-1])
@@ -1637,8 +1637,8 @@ class Tester(object):
             t_err_max = min(tOld[-1], tNew[-1])
 
         if (abs(tOld[0] - tNew[0]) > 1E-5):
-            warning = (
-                "While processing file {} for variable {}: different start time between "
+            error = (
+                "While processing file {} for variable {}: Different start time between "
                 "reference and test data.\n"
                 "tNew = [{}, {}]\n"
                 "tOld = [{}, {}]\n").format(filNam, varNam, tNew[0], tNew[-1], tOld[0], tOld[-1])
@@ -1648,8 +1648,8 @@ class Tester(object):
         # The next test may be true if a simulation stopped with an error prior to
         # producing sufficient data points
         if len(yNew) < len(yOld) and len(yNew) > 2:
-            warning = (
-                "While processing file {} for variable {}: fewer data points than reference results.\n"
+            error = (
+                "While processing file {} for variable {}: Fewer data points than reference results.\n"
                 "len(yOld) = {}\n"
                 "len(yNew) = {}\n"
                 "Skipping error checking for this variable.\n").format(
@@ -1676,10 +1676,10 @@ class Tester(object):
                 tOld = getTimeGrid(tOld, len(yOld))
 
         if self._comp_tool == 'legacy':
-            try:  # In case a warning has been raised before: no comparison performed.
-                warning
+            try:  # In case a error has been raised before: no comparison performed.
+                error
             except NameError:
-                t_err_max, warning = self.legacy_comp(
+                t_err_max, error = self.legacy_comp(
                     tOld, yOld, tNew, yNew, tGriOld, tGriNew, varNam, filNam, self._tol['ay'])
         else:
             idx = self._init_comp_info(model_name, filNam)
@@ -1698,7 +1698,7 @@ class Tester(object):
                 # Now looking for the new variable group to be stored.
                 var_group = var_group_str + 1 + next(iv for iv, vl in enumerate(
                     self._data[data_idx]["ResultVariables"][(var_group_str + 1):]) if varNam in vl)
-                warning = comp_tmp['warnings'][var_idx]
+                error = comp_tmp['warnings'][var_idx]
                 t_err_max = comp_tmp['t_err_max'][var_idx]
                 self._update_comp_info(
                     idx,
@@ -1706,22 +1706,22 @@ class Tester(object):
                     fun_dir,
                     test_passed,
                     t_err_max,
-                    warning,
+                    error,
                     data_idx,
                     var_group)
             except (ValueError, StopIteration):
-                try:  # In case a warning has been raised before: no comparison performed.
+                try:  # In case a error has been raised before: no comparison performed.
                     self._update_comp_info(
-                        idx, varNam, None, test_passed, t_err_max, warning, data_idx)
+                        idx, varNam, None, test_passed, t_err_max, error, data_idx)
                 except NameError:
-                    t_err_max, warning = self.funnel_comp(
+                    t_err_max, error = self.funnel_comp(
                         tOld, yOld, tNew, yNew, varNam, filNam, model_name, self._tol, data_idx)
 
         test_passed = True
-        if warning is not None:
+        if error is not None:
             test_passed = False
 
-        return (test_passed, t_err_max, warning)
+        return (test_passed, t_err_max, error)
 
     def _isParameter(self, dataSeries):
         """ Return `True` if `dataSeries` is from a parameter.
@@ -1984,18 +1984,18 @@ class Tester(object):
                             t = t_sim
 
                         # Compare times series.
-                        (res, timMaxErr, warning) = self.areResultsEqual(
+                        (res, timMaxErr, error) = self.areResultsEqual(
                             t_ref, y_ref[varNam], t, pai[varNam], varNam, data_idx
                         )
 
-                        if warning:
-                            self._reporter.writeWarning(warning)
+                        if error:
+                            self._reporter.writeError(error)
                         if not res:
                             foundError = True
                             timOfMaxErr[varNam] = timMaxErr
                     else:
                         # There is no old data series for this variable name
-                        self._reporter.writeWarning(
+                        self._reporter.writeError(
                             "{}: Did not find variable {} in old results.".format(
                                 refFilNam, varNam))
                         foundError = True
@@ -2140,8 +2140,10 @@ class Tester(object):
         # sort it, and compare the entries for equality
 
         def g(s): return s.replace(" ", "").split(",")
-        sp1 = sorted(g(x))
-        sp2 = sorted(g(y))
+        # Sort and remove 0, as we are not interested in these equations because
+        # they are solved explicitely
+        sp1 = [x for x in sorted(g(x)) if x != '0']
+        sp2 = [x for x in sorted(g(y)) if x != '0']
         # If the list have different lengths, they are not equal
         if len(sp1) != len(sp2):
             return False

--- a/buildingspy/io/postprocess.py
+++ b/buildingspy/io/postprocess.py
@@ -143,11 +143,11 @@ class Plotter(object):
         :param increment: The time increment that is used in the plot
         :param nIncrement: The number of increments before the data are wrapped.
         :return: This method returns a
-                 `matplotlib.pyplot <https://matplotlib.org/api/pyplot_api.html>`_ object that can be further
+                 `matplotlib.pyplot <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.html>`_ object that can be further
                  processed, such as to label its axis.
 
         All other arguments are as explained at `matplotlib's boxplot documentation
-        <https://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.boxplot>`_.
+        <https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.boxplot.html>`_.
 
         The parameter ``increment`` is used to set the support points in time
         at which the statistics is made.

--- a/buildingspy/tests/test_development_regressiontest.py
+++ b/buildingspy/tests/test_development_regressiontest.py
@@ -192,7 +192,9 @@ class Test_regressiontest_Tester(unittest.TestCase):
         # 1, 2 is equal to 2, 1
         self.assertTrue(rt.are_statistics_equal("1, 2", "2, 1"))
         self.assertTrue(rt.are_statistics_equal("1, 40, 2", "2, 1, 40"))
-        self.assertFalse(rt.are_statistics_equal("1, 40", "1, 40, 0"))
+        # Zeros are ignored
+        self.assertTrue(rt.are_statistics_equal("1, 40", "1, 40, 0"))
+        self.assertTrue(rt.are_statistics_equal("1, 0, 0, 40", "1, 40, 0"))
 
     def test_format_float(self):
         import buildingspy.development.regressiontest as r

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core.
-jinja2==2.11.1
+jinja2==2.11.3
 gitpython==3.1.0; python_version>='3.6'
 --only-binary matplotlib==3.2.0; python_version>='3.6'
 --only-binary numpy==1.18.1; python_version>='3.6'


### PR DESCRIPTION
This closes #408 

Bumps [jinja2](https://github.com/pallets/jinja) from 2.11.1 to 2.11.3.
- [Release notes](https://github.com/pallets/jinja/releases)
- [Changelog](https://github.com/pallets/jinja/blob/master/CHANGES.rst)
- [Commits](https://github.com/pallets/jinja/compare/2.11.1...2.11.3)

Signed-off-by: dependabot[bot] <support@github.com>