### PR TITLE
Avoided copying .mat and .log files in CI tests

### DIFF
--- a/buildingspy/CHANGES.txt
+++ b/buildingspy/CHANGES.txt
@@ -4,6 +4,8 @@ BuildingsPy Changelog
 Version 2.2.0, xxx, 2020 -- Release 2.2
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - xxx
+- For unit tests, avoided copying .log and .mat files to temporary directory
+  (https://github.com/lbl-srg/BuildingsPy/issues/428)
 - For unit tests with Optimica, added check for access to component that are not present in constraining type of declaration
   (https://github.com/lbl-srg/BuildingsPy/issues/424)
 - For library merger, corrected erroneous replacement of IBPSA in name of issue number

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -3325,7 +3325,8 @@ class Tester(object):
                 ignore=shutil.ignore_patterns(
                     '.svn',
                     '.git',
-                    '.mat',
+                    '*.mat',
+                    '*.log',
                     'request.',
                     'status.',
                     'dsmodel.c',


### PR DESCRIPTION
This closes #428