### PR TITLE
Added Dymola temporary files to exclude list in merger

### DIFF
--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -55,6 +55,8 @@ class IBPSA(object):
         self._excluded_files = [os.path.join(ibpsa_dir, "package.mo"),
                                 os.path.join(ibpsa_dir, "dymosim"),
                                 os.path.join(ibpsa_dir, "request"),
+                                os.path.join(ibpsa_dir, "status"),
+                                os.path.join(ibpsa_dir, "success"),
                                 os.path.join(ibpsa_dir, "ds*.txt"),
                                 os.path.join(ibpsa_dir, "*.c"),
                                 os.path.join(ibpsa_dir, "*.exe"),

--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -54,6 +54,7 @@ class IBPSA(object):
                                     "Obsolete"])
         self._excluded_files = [os.path.join(ibpsa_dir, "package.mo"),
                                 os.path.join(ibpsa_dir, "dymosim"),
+                                os.path.join(ibpsa_dir, "dymosim.exe"),
                                 os.path.join(ibpsa_dir, "request"),
                                 os.path.join(ibpsa_dir, "status"),
                                 os.path.join(ibpsa_dir, "success"),


### PR DESCRIPTION
This adds the files `status` and `success` to the exclude list of the merger.