### PR TITLE
Corrected bug in git add that was run on a file that does not yet exist

### DIFF
--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -198,6 +198,7 @@ end %s;
             # This is also needed if a package is created, and then the parent package
             # moved as otherwise, "git mv" will fail as it operates on a file that is not in git
             _sh(cmd=['git', 'add', "package.mo"], directory=fd)
+            _sh(cmd=['touch', "package.order"], directory=fd)
             _sh(cmd=['git', 'add', "package.order"], directory=fd)
 
 


### PR DESCRIPTION
This fixes a bug in the refactor script that causes a run-time error due to running git add on a file that does not yet exist.