### PR TITLE
Fixed bug that ignored N when reference results do not yet exist

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -2765,7 +2765,7 @@ class Tester(object):
                                 for pai in y_sim:
                                     t_ref = pai["time"]
                                 noOldResults = noOldResults + list(pai.keys())
-                                if not self._batch:
+                                if not (self._batch or ans == "Y" or ans == "N"):
                                     self._legacy_plot(y_sim, t_ref, {}, noOldResults, dict(),
                                                       "New results: " + data['ScriptFile'])
                                 # Reference file does not exist


### PR DESCRIPTION
This fixes a bug that causes to ignore N if a reference result file does not yet exist