### PR TITLE
Updated image of dymola and omc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ cache: pip
 
 env:
   global:
-    - OMC_VERSION=ubuntu-2004-omc:1.19.0_dev-539-gb76366f-1
+    - OMC_VERSION=ubuntu-2004-omc:1.19.0_dev-613-gd6e04c0-1
     - OPTIMICA_VERSION=travis-ubuntu-1804-optimica:r26446
-    - DYMOLA_VERSION=travis_ubuntu-2004_dymola:2022x-x86_64
+    - DYMOLA_VERSION=travis_ubuntu-2004_dymola:2022x-x86_64_rev-2
     - MPLBACKEND=agg
 
 notifications:


### PR DESCRIPTION
This updates the docker images to ubuntu-2004-omc:1.19.0_dev-613-gd6e04c0-1 and travis_ubuntu-2004_dymola:2022x-x86_64_rev-2