### PR TITLE
Excluded all txt file in top-level package from merging

### DIFF
--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -60,7 +60,7 @@ class IBPSA(object):
                                 os.path.join(ibpsa_dir, "request"),
                                 os.path.join(ibpsa_dir, "status"),
                                 os.path.join(ibpsa_dir, "success"),
-                                os.path.join(ibpsa_dir, "ds*.txt"),
+                                os.path.join(ibpsa_dir, "*.txt"),
                                 os.path.join(ibpsa_dir, "*.c"),
                                 os.path.join(ibpsa_dir, "*.exe"),
                                 os.path.join(ibpsa_dir, "*.csv"),


### PR DESCRIPTION
This also avoids merging buildlog.txt