### PR TITLE
Corrected bug that causes renames to fail on Windows

### DIFF
--- a/buildingspy/CHANGES.txt
+++ b/buildingspy/CHANGES.txt
@@ -3,6 +3,7 @@ BuildingsPy Changelog
 
 Version 4.x.x, xxx -- Release 4.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+- Corrected bug in buildingspy/development/refactor.py that causes renames to fail on Windows.
 - Corrected bug in buildingspy/development/regressiontest.py in parsing .mos scripts with simulateModel command on multiple lines.
   (https://github.com/lbl-srg/BuildingsPy/issues/508)
 - Added class buildingspy.development.simulationCompare that compares

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -342,8 +342,8 @@ def _move_mos_file(source, target):
     else:
         sourceFile = get_modelica_file_name(source)
         targetFile = get_modelica_file_name(target)
-        targetMosFile = sourceMosFile.replace(os.path.join(*sourceFile.split("/")[1:]),
-                                              os.path.join(*targetFile.split("/")[1:]))
+        targetMosFile = sourceMosFile.replace(os.path.join(*sourceFile.split(os.path.sep)[1:]),
+                                              os.path.join(*targetFile.split(os.path.sep)[1:]))
 
     if os.path.isfile(sourceMosFile):
         # Remove the top-level package name from source and target, then


### PR DESCRIPTION
This closes #514