### PR TITLE
Fix IndexError: string index out of range

### DIFF
--- a/buildingspy/io/outputfile.py
+++ b/buildingspy/io/outputfile.py
@@ -145,7 +145,7 @@ def get_errors_and_warnings(log_file, simulator):
         elif simulator == "dymola" and lin == " = false\n":
             em = "Log file contained the line ' = false'"
             if index > 0:
-                em = f"{em}. Preceeding line: '{lin[index-1]}'"
+                em = f"{em}. Preceeding line: '{lines[index-1]}'"
             listErr.append(em)
 
     ret["warnings"] = listWarn


### PR DESCRIPTION
When a dymola simulation fails, python throws an IndexError: string index out of range instead of proper error reporting.

```
Traceback (most recent call last):
  File "C:\Program Files\Python\Python311\Lib\multiprocessing\pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python\Python311\Lib\multiprocessing\pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "C:\Users\calculator\Desktop\VehicleTES\Simulate_SystemOverview_MinMax.py", line 21, in simulateCase
    s.simulate()
  File "C:\Program Files\Python\Python311\Lib\site-packages\buildingspy\simulate\Dymola.py", line 287, in simulate
    self._check_simulation_errors(worDir)
  File "C:\Program Files\Python\Python311\Lib\site-packages\buildingspy\simulate\Dymola.py", line 399, in _check_simulation_errors
    ret = get_errors_and_warnings(path_to_logfile, 'dymola')
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Program Files\Python\Python311\Lib\site-packages\buildingspy\io\outputfile.py", line 148, in get_errors_and_warnings
    em = f"{em}. Preceeding line: '{lin[index-1]}'"
                                    ~~~^^^^^^^^^
IndexError: string index out of range
```