### PR TITLE
Correct error message if dymola has a simulation error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   global:
     - DOCKER_REPONAME=lbnlblum
     - OMC_VERSION=ubuntu-2204-omc:1.22.0_dev-41-g8a5b18f-1
-    - OPTIMICA_VERSION=travis-ubuntu-2204-optimica:1.43.4
+    - OPTIMICA_VERSION=travis-ubuntu-2204-optimica:1.48.2
     - DYMOLA_VERSION=travis_ubuntu-2004_dymola:2023x-x86_64_rev-1
     - MPLBACKEND=agg
 

--- a/buildingspy/CHANGES.txt
+++ b/buildingspy/CHANGES.txt
@@ -5,6 +5,8 @@ Version 5.0.x, xxxx
 ^^^^^^^^^^^^^^^^^^^
 - In buildingspy/development/regressiontest.py, corrected bug that caused CI tests to not fail if run in batch
   mode and a reference file was missing.
+- In buildingspy/io/outputfile.py, corrected error reporting for Dymola that caused a string index out of range.
+  (https://github.com/lbl-srg/BuildingsPy/issues/536)
 
 Version 5.0.0, September 1, 2023 -- Release 5.0
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/buildingspy/io/outputfile.py
+++ b/buildingspy/io/outputfile.py
@@ -145,7 +145,7 @@ def get_errors_and_warnings(log_file, simulator):
         elif simulator == "dymola" and lin == " = false\n":
             em = "Log file contained the line ' = false'"
             if index > 0:
-                em = f"{em}. Preceeding line: '{lin[index-1]}'"
+                em = f"{em}. Preceeding line: '{lines[index-1]}'"
             listErr.append(em)
 
     ret["warnings"] = listWarn


### PR DESCRIPTION
This corrects a `string index out of range` due to access of the wrong data structure.
This closes #536 