### PR TITLE
Compatibility with newer Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ pytidylib==0.3.2
 simplejson==3.16.0
 six==1.14.0
 pyfunnel==0.3.0
-PyYAML==5.4
+PyYAML==6.0.1
 cerberus==1.3.4
 
 # For documentation and testing.

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'simplejson>=3.16',
         'six>=1.14',
         'pyfunnel>=0.3.0',
-        'PyYAML>=5.4',
+        'PyYAML>=6.0.1',
         'cerberus>=1.3.4',
     ],
     packages=[


### PR DESCRIPTION
Installing with Python >= 3.10 is not possible "out-of-the-box"
[It seems there is an issue with PyYAML not being compatible with Cython >= 3](https://github.com/yaml/pyyaml/issues/724)

Installing PyYAML 6.0.1 instead solves the issue (tested with a fresh install of Python 3.10.14 and Python 3.12.3)

[PyYAML changes:](https://github.com/yaml/pyyaml/blob/main/CHANGES)

6.0.1 (2023-07-18)

* https://github.com/yaml/pyyaml/pull/702 -- pin Cython build dep to < 3.0

6.0 (2021-10-13)

* https://github.com/yaml/pyyaml/pull/327 -- Change README format to Markdown
* https://github.com/yaml/pyyaml/pull/483 -- Add a test for YAML 1.1 types
* https://github.com/yaml/pyyaml/pull/497 -- fix float resolver to ignore `.` and `._`
* https://github.com/yaml/pyyaml/pull/550 -- drop Python 2.7
* https://github.com/yaml/pyyaml/pull/553 -- Fix spelling of “hexadecimal”
* https://github.com/yaml/pyyaml/pull/556 -- fix representation of Enum subclasses
* https://github.com/yaml/pyyaml/pull/557 -- fix libyaml extension compiler warnings
* https://github.com/yaml/pyyaml/pull/560 -- fix ResourceWarning on leaked file descriptors
* https://github.com/yaml/pyyaml/pull/561 -- always require `Loader` arg to `yaml.load()`
* https://github.com/yaml/pyyaml/pull/564 -- remove remaining direct distutils usage

