### PR TITLE
Problem with moving images files - Using the shutil method to copy folders

### DIFF
--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -17,6 +17,7 @@
 """
 import os
 import re
+import shutil
 
 __all__ = ["create_modelica_package", "move_class", "write_package_order"]
 
@@ -202,7 +203,7 @@ end %s;
             _sh(cmd=['git', 'add', "package.order"], directory=fd)
 
 
-def _git_move(source, target):
+def _git_move(source, target, _shutil = False):
     """ Moves `source` to `target` using `git mv`.
 
     This method calls `git mv source target` in the current directory.
@@ -247,7 +248,14 @@ def _git_move(source, target):
             # Directory does not exist.
             os.makedirs(targetDir)
 
-    _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
+    if _shutil == False:
+        _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
+    else:
+        if os.path.isdir(source):
+            shutil.copytree(os.path.join(os.path.curdir,source), os.path.join(os.path.curdir,target), dirs_exist_ok=True)
+        else:
+            shutil.copy2(os.path.join(os.path.curdir,source), os.path.join(os.path.curdir,target))
+        shutil.rmtree(source)
 
 
 def get_modelica_file_name(source):
@@ -590,7 +598,7 @@ def _move_images_directory(source, target):
 
     if os.path.isdir(source_dir):
         target_dir = target.replace(".", os.path.sep).replace(os.path.sep, insertion, 1)
-        _git_move(source_dir, target_dir)
+        _git_move(source_dir, target_dir, _shutil=True)
 
 
 def _move_class_directory(source, target):


### PR DESCRIPTION
It is possible to change the directory of `DHC` from `Buildings.Experimental.DHC` to `Buildings.DHC` thanks to the function `move_class`. During the process, the images are moved recursively via the function `_move_class_directory` that calls for each folder the function `_move_images_directory`. To move the folders, the command line `git mv` is used.

For example, the package `Buildings. Experimental .DHC.EnergyTransferStations.Combined` has 2 images, `PartialParallel` and `ChillerBorefield`. 
During the first iteration, for `BaseClasses.PartialParallel`, `Resources\Images\Experimental\DHC\EnergyTransferStations\Combined\BaseClasses` is moved to `Resources\Images\DHC\EnergyTransferStations\Combined\BaseClasses`, which is the expected behavior.
BUT during the second iteration for `ChillerBorefield`, instead of moving to `Resources\Images\DHC\EnergyTransferStations\Combined`, the image goes to `Resources\Images\DHC\EnergyTransferStations\Combined\Combined` because of the behavior of
`git mv` (`Resources\Images\DHC\EnergyTransferStations\Combined` already exists). 

The proposed alternative is to use `shutil` package (part of the standard Python distribution, OS agnostic) instead of `git mv`.
At the moment the function `_git_move` is only used with the variable `_shutil=True` within the function `_move_images_directory`, but it may fully replace the `git mv` method.

The downside is that it is not considered in `git` as a "rename" but as a new file (new folder)/deleted file (old folder).

Also, the function used may be refined to adapt to every context.

Finally, for `git` use, the following could be used:

```
_sh(cmd=['git', 'rm', '-r', source], directory=os.path.curdir)
_sh(cmd=['git', 'add', target], directory=os.path.curdir)
```

Instead of `shutil.rmtree(source)`