### PR TITLE
Problem copying images

### DIFF
--- a/buildingspy/CHANGES.txt
+++ b/buildingspy/CHANGES.txt
@@ -4,6 +4,9 @@ BuildingsPy Changelog
 Version 5.2.0, xxxx
 ^^^^^^^^^^^^^^^^^^^
 
+- In buildingspy/development/refactor.py, corrected moving images to avoid creating
+  a directory if the target directory already exists.
+  (https://github.com/lbl-srg/BuildingsPy/pull/548)
 - In buildingspy/development/validator.py, added method validateHyperlinks()
   that searches for broken hyperlinks.
   (https://github.com/lbl-srg/BuildingsPy/issues/544)

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -246,8 +246,17 @@ def _git_move(source, target):
         else:
             # Directory does not exist.
             os.makedirs(targetDir)
-
-    _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
+    
+    if os.path.isdir(target):
+        # If Linux is used, the following lines can be used intead:
+        # _sh(cmd=['git', 'mv', os.path.join(source, '*'), target], directory=os.path.curdir)
+        # os.rmdir(source)
+        list_files = os.listdir(source)
+        for k in list_files:
+            _sh(cmd=['git', 'mv', os.path.join(source, k), target], directory=os.path.curdir)
+        os.rmdir(source)
+    else:
+        _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
 
 
 def get_modelica_file_name(source):

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -248,16 +248,14 @@ def _git_move(source, target):
             os.makedirs(targetDir)
     
     if os.path.isdir(target):
-        # If Linux is used, the following lines can be used intead:
-        # _sh(cmd=['git', 'mv', os.path.join(source, '*'), target], directory=os.path.curdir)
-        # os.rmdir(source)
+        # Target exists, move files individually.
+        # See https://github.com/lbl-srg/BuildingsPy/pull/548
         list_files = os.listdir(source)
         for k in list_files:
             _sh(cmd=['git', 'mv', os.path.join(source, k), target], directory=os.path.curdir)
         os.rmdir(source)
     else:
         _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
-
 
 def get_modelica_file_name(source):
     """ Return for the Modelica class `source` its file name.

--- a/buildingspy/development/refactor.py
+++ b/buildingspy/development/refactor.py
@@ -246,7 +246,7 @@ def _git_move(source, target):
         else:
             # Directory does not exist.
             os.makedirs(targetDir)
-    
+
     if os.path.isdir(target):
         # Target exists, move files individually.
         # See https://github.com/lbl-srg/BuildingsPy/pull/548
@@ -256,6 +256,7 @@ def _git_move(source, target):
         os.rmdir(source)
     else:
         _sh(cmd=['git', 'mv', source, target], directory=os.path.curdir)
+
 
 def get_modelica_file_name(source):
     """ Return for the Modelica class `source` its file name.


### PR DESCRIPTION
It is possible to change the directory of `DHC` from `Buildings.Experimental.DHC` to `Buildings.DHC` thanks to the function `move_class`. During the process, the images are moved recursively via the function `_move_class_directory` that calls for each folder the function `_move_images_directory`. To move the folders, the command line `git mv` is used.

For example, the package `Buildings. Experimental .DHC.EnergyTransferStations.Combined` has 2 images, `PartialParallel` and `ChillerBorefield`. 
During the first iteration, for `BaseClasses.PartialParallel`, `Resources\Images\Experimental\DHC\EnergyTransferStations\Combined\BaseClasses` is moved to `Resources\Images\DHC\EnergyTransferStations\Combined\BaseClasses`, which is the expected behavior.
BUT during the second iteration for `ChillerBorefield`, instead of moving to `Resources\Images\DHC\EnergyTransferStations\Combined`, the image goes to `Resources\Images\DHC\EnergyTransferStations\Combined\Combined` because of the behavior of
`git mv` (`Resources\Images\DHC\EnergyTransferStations\Combined` already exists). 

The proposed alternative is, when a folder already exists, to copy the files from the `source` folder to the `target` folder.
On Linux, the command `git mv source/*` exists, on Windows also if someone is using `git-bash.exe` but not with Windows shell (see for example [https://stackoverflow.com/questions/7130850/how-can-i-move-all-git-content-one-level-up-in-the-folder-hierarchy)](https://stackoverflow.com/questions/7130850/how-can-i-move-all-git-content-one-level-up-in-the-folder-hierarchy)
A workaround (proposed solution) is to list all the files within the folder and move them individually.
Then the source folder is deleted.