### PR TITLE
Exclude .bak-mo from merging

### DIFF
--- a/buildingspy/development/merger.py
+++ b/buildingspy/development/merger.py
@@ -68,6 +68,7 @@ class IBPSA(object):
                                 os.path.join(ibpsa_dir, "*.mat"),
                                 os.path.join(ibpsa_dir, "*.fmu"),
                                 os.path.join(ibpsa_dir, "*.mos"),
+                                os.path.join(ibpsa_dir, "*.bak-mo"),
                                 os.path.join(ibpsa_dir, "*.mof"),
                                 os.path.join(ibpsa_dir, "*.pyc"),
                                 os.path.join(ibpsa_dir, "*.pdf"),


### PR DESCRIPTION
This exludes the .bak-mo from being merged