### PR TITLE
Enable creation of new reference results in batch mode

### DIFF
--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -367,10 +367,6 @@ class Tester(object):
         # By default, do not show the GUI of the simulator
         self._showGUI = False
 
-        # Possible additional startup.mos or library package
-        self._startup_mos_path = None
-        self._addLibPackage = None
-
         # Enable or disable colored output on non-windows
         if color and (platform.system() != "Windows"):
             self._color_BOLD = '\033[1m'
@@ -3226,14 +3222,6 @@ DDE_orig = sett[{posDDE}];
 sett[{posDDE}] = \"DDE=0\"; // Disable DDE
 SetDymolaCompiler(comp, sett);
 """)
-        # Possible additional mos-script:
-        if self._startup_mos_path is not None:
-            runFil.write(f"""
-    // Possible execution of additional .mos script to load other libraries
-    RunScript("{self._startup_mos_path}");
-    """)
-        if self._addLibPackage is not None:
-            runFil.write(('openModel(\"{}\", changeDirectory=false);\n').format(self._addLibPackage))
 
         runFil.write('cd(\"{}/{}\");\n'.format(
             (self._temDir[iPro]).replace("\\", "/"),
@@ -4311,37 +4299,3 @@ exit();
         model = '.'.join(splt[root:])
         # remove the '.mo' at the end
         return model[:-3]
-
-    def setStartupMOS(self, path: str):
-        """
-        Set an additional startup.mos script to e.g. load additional libraries
-
-        :param str path:
-            Absolute path to the mos file.
-            As the working directory during testing is a temporary directory, relative paths won't work.
-
-        Usage: Type
-           >>> import os
-           >>> import buildingspy.development.regressiontest as r
-           >>> rt = r.Tester()
-           >>> startupMOS = os.path.join("path_to", "startup.mos")
-           >>> rt.setStartupMOS(startupMOS)
-        """
-        self._startup_mos_path = path
-
-    def setAdditionalLibResource(self, addLibPackage):
-        """ Set an additional library directory that should be loaded.
-        :param addLibPackage: The top-most directory of the add library as
-        absolute path.
-        The addLibPackage directory is the directory that contains
-        the top-level ``package.mo`` file of the additional library that is
-        needed to run the tests.
-
-        Usage: Type
-           >>> import os
-           >>> import buildingspy.development.regressiontest as r
-           >>> rt = r.Tester()
-           >>> myAddLib = os.path.join("myFolder", "myPackage", "package.mo")
-           >>> rt.setAdditionalLibResource(myAddLib)
-        """
-        self._addLibPackage = os.path.join(addLibPackage)

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -364,7 +364,7 @@ class Tester(object):
         self._error_dict = e.ErrorDictionary()
 
         # By default, do not show the GUI of the simulator
-        self._showGUI = True
+        self._showGUI = False
 
         # Possible additional startup.mos or library package
         self._startup_mos_path = None

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -3521,6 +3521,8 @@ Advanced.GenerateVariableDependencies = orig_Advanced_GenerateVariableDependenci
 exit();
 """)
         runFil.close()
+        with open(os.path.join(self._temDir[iPro], self.getLibraryName(), f"run_{tra_data['model_name']}.mos"), mode="r", encoding="utf-8") as file:
+            print(file.read())
         return
 
     def _write_runscripts(self):

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -366,6 +366,10 @@ class Tester(object):
         # By default, do not show the GUI of the simulator
         self._showGUI = False
 
+        # Possible additional startup.mos or library package
+        self._startup_mos_path = None
+        self._addLibPackage = None
+
         # Enable or disable colored output on non-windows
         if color and (platform.system() != "Windows"):
             self._color_BOLD = '\033[1m'
@@ -3216,6 +3220,16 @@ SetDymolaCompiler(comp, sett);
         runFil.write('cd(\"{}/{}\");\n'.format(
             (self._temDir[iPro]).replace("\\", "/"),
             self.getLibraryName()))
+
+        # Possible additional mos-script:
+        if self._startup_mos_path is not None:
+            runFil.write(f"""
+// Possible execution of additional .mos script to load other libraries
+runScript("{self._startup_mos_path}");
+""")
+        if self._addLibPackage is not None:
+            runFil.write(('openModel(\"{}\");\n').format(self._addLibPackage))
+
         runFil.write(f"""
 openModel("package.mo")
 // Add a flag so that translation info appears in console output.
@@ -4288,3 +4302,37 @@ exit();
         model = '.'.join(splt[root:])
         # remove the '.mo' at the end
         return model[:-3]
+
+    def setStartupMOS(self, path: str):
+        """
+        Set an additional startup.mos script to e.g. load additional libraries
+
+        :param str path:
+            Absolute path to the mos file.
+            As the working directory during testing is a temporary directory, relative paths won't work.
+
+        Usage: Type
+           >>> import os
+           >>> import buildingspy.development.regressiontest as r
+           >>> rt = r.Tester()
+           >>> startupMOS = os.path.join("path_to", "startup.mos")
+           >>> rt.setStartupMOS(startupMOS)
+        """
+        self._startup_mos_path = path
+
+    def setAdditionalLibResource(self, addLibPackage):
+        """ Set an additional library directory that should be loaded.
+        :param addLibPackage: The top-most directory of the add library as
+        absolute path.
+        The addLibPackage directory is the directory that contains
+        the top-level ``package.mo`` file of the additional library that is
+        needed to run the tests.
+
+        Usage: Type
+           >>> import os
+           >>> import buildingspy.development.regressiontest as r
+           >>> rt = r.Tester()
+           >>> myAddLib = os.path.join("myFolder", "myPackage", "package.mo")
+           >>> rt.setAdditionalLibResource(myAddLib)
+        """
+        self._addLibPackage = os.path.join(addLibPackage)

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -3225,7 +3225,7 @@ SetDymolaCompiler(comp, sett);
         if self._startup_mos_path is not None:
             runFil.write(f"""
 // Possible execution of additional .mos script to load other libraries
-runScript("{self._startup_mos_path}");
+RunScript("{self._startup_mos_path}");
 """)
         if self._addLibPackage is not None:
             runFil.write(('openModel(\"{}\");\n').format(self._addLibPackage))
@@ -3521,8 +3521,6 @@ Advanced.GenerateVariableDependencies = orig_Advanced_GenerateVariableDependenci
 exit();
 """)
         runFil.close()
-        with open(os.path.join(self._temDir[iPro], self.getLibraryName(), f"run_{tra_data['model_name']}.mos"), mode="r", encoding="utf-8") as file:
-            print(file.read())
         return
 
     def _write_runscripts(self):

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -535,7 +535,6 @@ class Tester(object):
         self._batch = batchMode
         self._createNewReferenceResultsInBatchMode = createNewReferenceResultsInBatchMode
 
-
     def pedanticModelica(self, pedanticModelica):
         """ Set the pedantic Modelica mode flag.
 
@@ -2824,7 +2823,9 @@ class Tester(object):
                                         updateReferenceData = True
                                     else:
                                         self._reporter.writeError(
-                                            f"Reference file {refFilNam} does not yet exist. You need to generate it by running tests in non-batch mode.")
+                                            f"Reference file {refFilNam} does not yet exist. "
+                                            f"You need to generate it by running tests in non-batch mode."
+                                        )
 
                                 if not (self._batch or ans == "Y" or ans == "N"):
                                     if t_ref is None:
@@ -3222,11 +3223,9 @@ DDE_orig = sett[{posDDE}];
 sett[{posDDE}] = \"DDE=0\"; // Disable DDE
 SetDymolaCompiler(comp, sett);
 """)
-
         runFil.write('cd(\"{}/{}\");\n'.format(
             (self._temDir[iPro]).replace("\\", "/"),
             self.getLibraryName()))
-
         runFil.write(f"""
 openModel("package.mo")
 // Add a flag so that translation info appears in console output.

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -364,7 +364,7 @@ class Tester(object):
         self._error_dict = e.ErrorDictionary()
 
         # By default, do not show the GUI of the simulator
-        self._showGUI = False
+        self._showGUI = True
 
         # Possible additional startup.mos or library package
         self._startup_mos_path = None
@@ -593,6 +593,7 @@ class Tester(object):
         elif self._modelica_tool != 'dymola':
             return 'jm_ipython.sh'
         else:
+            return r"C:\Program Files\Dymola 2023x\bin64\Dymola"
             return self._modelica_tool
 
     def isExecutable(self, program):
@@ -3217,18 +3218,18 @@ DDE_orig = sett[{posDDE}];
 sett[{posDDE}] = \"DDE=0\"; // Disable DDE
 SetDymolaCompiler(comp, sett);
 """)
-        runFil.write('cd(\"{}/{}\");\n'.format(
-            (self._temDir[iPro]).replace("\\", "/"),
-            self.getLibraryName()))
-
         # Possible additional mos-script:
         if self._startup_mos_path is not None:
             runFil.write(f"""
-// Possible execution of additional .mos script to load other libraries
-RunScript("{self._startup_mos_path}");
-""")
+    // Possible execution of additional .mos script to load other libraries
+    RunScript("{self._startup_mos_path}");
+    """)
         if self._addLibPackage is not None:
-            runFil.write(('openModel(\"{}\");\n').format(self._addLibPackage))
+            runFil.write(('openModel(\"{}\", changeDirectory=false);\n').format(self._addLibPackage))
+
+        runFil.write('cd(\"{}/{}\");\n'.format(
+            (self._temDir[iPro]).replace("\\", "/"),
+            self.getLibraryName()))
 
         runFil.write(f"""
 openModel("package.mo")

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -287,6 +287,7 @@ class Tester(object):
         self._statistics_log = "statistics.json"
         self._nPro = multiprocessing.cpu_count()
         self._batch = False
+        self._createNewReferenceResultsInBatchMode = False
         self._pedanticModelica = False
 
         # Number of data points that are used
@@ -514,15 +515,18 @@ class Tester(object):
         self._showGUI = show
         return
 
-    def batchMode(self, batchMode):
+    def batchMode(self, batchMode, createNewReferenceResultsInBatchMode: bool = False):
         """ Set the batch mode flag.
 
         :param batchMode: Set to ``True`` to run without interactive prompts
                           and without plot windows.
+        :param createNewReferenceResultsInBatchMode: Set to ``True`` to create
+                                                     new results in batch mode. Default is False.
 
         By default, the regression tests require the user to respond if results differ from previous simulations.
         This method can be used to run the script in batch mode, suppressing all prompts that require
-        the user to enter a response. If run in batch mode, no new results will be stored.
+        the user to enter a response.
+        By default, if run in batch mode, no new results will be stored.
         To run the regression tests in batch mode, enter
 
         >>> import os
@@ -533,6 +537,8 @@ class Tester(object):
 
         """
         self._batch = batchMode
+        self._createNewReferenceResultsInBatchMode = createNewReferenceResultsInBatchMode
+
 
     def pedanticModelica(self, pedanticModelica):
         """ Set the pedantic Modelica mode flag.
@@ -2836,7 +2842,7 @@ class Tester(object):
                                             print("             Create new file?")
                                             ans = input(
                                                 "             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
-                                        if ans == "y" or ans == "Y":
+                                        if ans == "y" or ans == "Y" or self._createNewReferenceResultsInBatchMode:
                                             updateReferenceData = True
                                         else:
                                             self._reporter.writeError(

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -593,7 +593,6 @@ class Tester(object):
         elif self._modelica_tool != 'dymola':
             return 'jm_ipython.sh'
         else:
-            return r"C:\Program Files\Dymola 2023x\bin64\Dymola"
             return self._modelica_tool
 
     def isExecutable(self, program):

--- a/buildingspy/development/regressiontest.py
+++ b/buildingspy/development/regressiontest.py
@@ -2824,8 +2824,11 @@ class Tester(object):
                                     noOldResults = noOldResults + list(pai.keys())
 
                                 if self._batch:
-                                    self._reporter.writeError(
-                                        f"Reference file {refFilNam} does not yet exist. You need to generate it by running tests in non-batch mode.")
+                                    if self._createNewReferenceResultsInBatchMode:
+                                        updateReferenceData = True
+                                    else:
+                                        self._reporter.writeError(
+                                            f"Reference file {refFilNam} does not yet exist. You need to generate it by running tests in non-batch mode.")
 
                                 if not (self._batch or ans == "Y" or ans == "N"):
                                     if t_ref is None:
@@ -2842,7 +2845,7 @@ class Tester(object):
                                             print("             Create new file?")
                                             ans = input(
                                                 "             Enter: y(yes), n(no), Y(yes for all), N(no for all): ")
-                                        if ans == "y" or ans == "Y" or self._createNewReferenceResultsInBatchMode:
+                                        if ans == "y" or ans == "Y":
                                             updateReferenceData = True
                                         else:
                                             self._reporter.writeError(


### PR DESCRIPTION
Closes #560 

@mwetter : 
- I tried to look for tests where new results are generated, but found None. If you have one, I could write a case with `createNewReferenceResultsInBatchMode=True`. 
- As it is linked to batchMode, I went for the same "set"-method. 
- This PR has some debugging commits, feel free to squash and merge this. 
